### PR TITLE
[Encoder] Adds missing derives for AsString (fixes #1).

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -671,6 +671,7 @@ where
 }
 
 /// Wrapper to allow `Vec<u8>` encoding as bencode string element.
+#[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct AsString<I>(pub I);
 
 impl<I> Encodable for AsString<I>


### PR DESCRIPTION
As the title mentions this adds all the missing derives for the `AsString` wrapper.