### PR TITLE
Bump `regex` and remove `failure-derive`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ failure = "^0.1"
 failure_derive = "^0.1"
 
 [dev-dependencies]
-regex = "^0.2"
+regex = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ maintenance = {status = "actively-developed"}
 lto = true
 
 [dependencies]
-failure = "^0.1"
-failure_derive = "^0.1"
+failure = "^0.1.3"
 
 [dev-dependencies]
 regex = "^1.0"

--- a/examples/decode_torrent.rs
+++ b/examples/decode_torrent.rs
@@ -15,10 +15,8 @@
 //! ```
 
 extern crate bendy;
-extern crate failure;
-
 #[macro_use]
-extern crate failure_derive;
+extern crate failure;
 
 use std::str;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(needless_return))]
 #![cfg_attr(not(test), warn(missing_docs))]
 
-extern crate failure;
 #[macro_use]
-extern crate failure_derive;
+extern crate failure;
 
 #[cfg(test)]
 extern crate regex;


### PR DESCRIPTION
This updates `regex` from 0.2 to 1.0 and also removes the direct dependency on `failure_derive` which can now be loaded through a reexport inside `failure`.