### PR TITLE
Introduce deserialization trait

### DIFF
--- a/examples/encode_torrent.rs
+++ b/examples/encode_torrent.rs
@@ -15,7 +15,7 @@
 
 use std::io::Write;
 
-use bendy::encoding::{AsString, Encodable, Error as EncodingError, SingleItemEncoder};
+use bendy::encoding::{AsString, Error as EncodingError, SingleItemEncoder, ToBencode};
 use failure::Error;
 
 /// Main struct containing all required information.
@@ -45,7 +45,7 @@ struct Info {
     pub file_length: String,
 }
 
-impl Encodable for MetaInfo {
+impl ToBencode for MetaInfo {
     // Adds an additional recursion level -- itself formatted as dictionary --
     // around the info struct.
     const MAX_DEPTH: usize = Info::MAX_DEPTH + 1;
@@ -75,7 +75,7 @@ impl Encodable for MetaInfo {
     }
 }
 
-impl Encodable for Info {
+impl ToBencode for Info {
     // The struct is encoded as dictionary and all of it internals are encoded
     // as flat values, i.e. strings or integers.
     const MAX_DEPTH: usize = 1;
@@ -108,7 +108,7 @@ fn main() -> Result<(), Error> {
         },
     };
 
-    let data = torrent.to_bytes()?;
+    let data = torrent.to_bencode()?;
     std::io::stdout().write_all(&data)?;
 
     Ok(())

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -64,10 +64,12 @@
 //! ```
 mod decoder;
 mod error;
+mod from_bencode;
 mod object;
 
 pub use self::{
     decoder::{Decoder, DictDecoder, ListDecoder},
     error::{Error, ErrorKind, ResultExt},
+    from_bencode::FromBencode,
     object::Object,
 };

--- a/src/decoding/from_bencode.rs
+++ b/src/decoding/from_bencode.rs
@@ -1,0 +1,137 @@
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+    rc::Rc,
+};
+
+use crate::{
+    decoding::{Decoder, Error, Object},
+    encoding::AsString,
+    state_tracker::StructureError,
+};
+
+///Basic trait for bencode based value deserialization.
+pub trait FromBencode {
+    /// Maximum allowed depth of nested structures before the decoding should be aborted.
+    const EXPECTED_RECURSION_DEPTH: usize = 2048;
+
+    /// Deserialize an object from its byte representation.
+    fn from_bencode(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let mut decoder = Decoder::new(bytes).with_max_depth(Self::EXPECTED_RECURSION_DEPTH);
+        let object = decoder.next_object()?;
+
+        object.map_or(
+            Err(Error::from(StructureError::UnexpectedEof)),
+            Self::decode_bencode_object,
+        )
+    }
+
+    /// Deserialize an object from its intermediate bencode representation.
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized;
+}
+
+macro_rules! impl_from_bencode_for_integer {
+    ($($type:ty)*) => {$(
+        impl FromBencode for $type {
+            const EXPECTED_RECURSION_DEPTH: usize = 0;
+
+            fn decode_bencode_object(object: Object) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                let content = object.try_into_integer()?;
+                let number = content.parse::<$type>()?;
+
+                Ok(number)
+            }
+        }
+    )*}
+}
+
+impl_from_bencode_for_integer!(u8 u16 u32 u64 usize i8 i16 i32 i64 isize);
+
+impl<ContentT: FromBencode> FromBencode for Vec<ContentT> {
+    const EXPECTED_RECURSION_DEPTH: usize = ContentT::EXPECTED_RECURSION_DEPTH + 1;
+
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let mut list = object.try_into_list()?;
+        let mut results = Vec::new();
+
+        while let Some(object) = list.next_object()? {
+            let item = ContentT::decode_bencode_object(object)?;
+            results.push(item);
+        }
+
+        Ok(results)
+    }
+}
+
+impl FromBencode for String {
+    const EXPECTED_RECURSION_DEPTH: usize = 0;
+
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let content = object.try_into_bytes()?;
+        let content = String::from_utf8(content.to_vec())?;
+
+        Ok(content)
+    }
+}
+
+impl<K, V, H> FromBencode for HashMap<K, V, H>
+where
+    K: FromBencode + Hash + Eq,
+    V: FromBencode,
+    H: BuildHasher + Default,
+{
+    const EXPECTED_RECURSION_DEPTH: usize = V::EXPECTED_RECURSION_DEPTH + 1;
+
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let mut dict = object.try_into_dictionary()?;
+        let mut result = HashMap::default();
+
+        while let Some((key, value)) = dict.next_pair()? {
+            let key = K::decode_bencode_object(Object::Bytes(key))?;
+            let value = V::decode_bencode_object(value)?;
+
+            result.insert(key, value);
+        }
+
+        Ok(result)
+    }
+}
+
+impl<T: FromBencode> FromBencode for Rc<T> {
+    const EXPECTED_RECURSION_DEPTH: usize = T::EXPECTED_RECURSION_DEPTH;
+
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        T::decode_bencode_object(object).map(Rc::new)
+    }
+}
+
+impl FromBencode for AsString<Vec<u8>> {
+    const EXPECTED_RECURSION_DEPTH: usize = 0;
+
+    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        object.try_into_bytes().map(Vec::from).map(AsString)
+    }
+}

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -2,18 +2,18 @@
 //!
 //! # Encoding a structure
 //!
-//! The easiest way to encode a structure is to implement [`Encodable`] for it. For most structures,
+//! The easiest way to encode a structure is to implement [`ToBencode`] for it. For most structures,
 //! this should be very simple:
 //!
 //! ```
-//! # use bendy::encoding::{Encodable, SingleItemEncoder, Error};
+//! # use bendy::encoding::{ToBencode, SingleItemEncoder, Error};
 //!
 //! struct Message {
 //!     foo: i32,
 //!     bar: String,
 //! }
 //!
-//! impl Encodable for Message {
+//! impl ToBencode for Message {
 //!     // Atoms have depth one. The struct wrapper adds one level to that
 //!     const MAX_DEPTH: usize = 1;
 //!
@@ -28,17 +28,17 @@
 //! }
 //! ```
 //!
-//! Then, messages can be serialized using [`Encodable::to_bytes`]:
+//! Then, messages can be serialized using [`ToBencode::to_bencode`]:
 //!
 //! ```
-//! # use bendy::encoding::{Encodable, SingleItemEncoder, Error};
+//! # use bendy::encoding::{ToBencode, SingleItemEncoder, Error};
 //! #
 //! # struct Message {
 //! #    foo: i32,
 //! #    bar: String,
 //! # }
 //! #
-//! # impl Encodable for Message {
+//! # impl ToBencode for Message {
 //! #     // Atoms have depth zero. The struct wrapper adds one level to that
 //! #     const MAX_DEPTH: usize = 1;
 //! #
@@ -57,16 +57,16 @@
 //! Message{
 //!     foo: 1,
 //!     bar: "quux".to_string(),
-//! }.to_bytes()
+//! }.to_bencode()
 //! # ;
 //! # assert!(result.is_ok());
 //! ```
 //!
-//! Most primitive types already implement [`Encodable`].
+//! Most primitive types already implement [`ToBencode`].
 //!
 //! # Nesting depth limits
 //!
-//! To allow this to be used on limited platforms, all implementations of [`Encodable`] include a
+//! To allow this to be used on limited platforms, all implementations of [`ToBencode`] include a
 //! maximum nesting depth. Atoms (integers and byte strings) are considered to have depth 0. An
 //! object (a list or dict) containing only atoms has depth 1, and in general, an object has a depth
 //! equal to the depth of its deepest member plus one. In some cases, an object doesn't have a
@@ -75,7 +75,7 @@
 //! appropriate buffer for the depth:
 //!
 //! ```
-//! # use bendy::encoding::{Encodable, Encoder, Error};
+//! # use bendy::encoding::{ToBencode, Encoder, Error};
 //! #
 //! # type ObjectType = u32;
 //! # static object: u32 = 0;
@@ -94,23 +94,24 @@
 //!
 //! Once an error occurs during encoding, all future calls to the same encoding stream will fail
 //! early with the same error. It is not defined whether any callback or implementation of
-//! [`Encodable::encode`] is called before returning an error; such callbacks should respond to
-//! failure by bailing out as quickly as possible.
+//! [`ToBencode::encode`] is called before returning an error; such callbacks should
+//! respond to failure by bailing out as quickly as possible.
 //!
 //! Not all values in [`Error`] can be caused by an encoding operation. Specifically, you only need
 //! to worry about [`UnsortedKeys`] and [`NestingTooDeep`].
 //!
+//! [`ToBencode::encode`]: self::ToBencode::encode
 //! [`UnsortedKeys`]: self::Error#UnsortedKeys
 //! [`NestingTooDeep`]: self::Error#NestingTooDeep
 
-mod encodable;
 mod encoder;
 mod error;
 mod printable_integer;
+mod to_bencode;
 
 pub use self::{
-    encodable::{AsString, Encodable},
     encoder::{Encoder, SingleItemEncoder, SortedDictEncoder, UnsortedDictEncoder},
     error::Error,
     printable_integer::PrintableInteger,
+    to_bencode::{AsString, ToBencode},
 };

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, io::Write};
 
 use crate::{
-    encoding::{Encodable, Error, PrintableInteger},
+    encoding::{Error, PrintableInteger, ToBencode},
     state_tracker::{StateTracker, StructureError, Token},
 };
 
@@ -50,7 +50,7 @@ impl Encoder {
     }
 
     /// Emit an arbitrary encodable object
-    pub fn emit<E: Encodable>(&mut self, value: E) -> Result<(), StructureError> {
+    pub fn emit<E: ToBencode>(&mut self, value: E) -> Result<(), StructureError> {
         self.emit_with(|e| value.encode(e).map_err(Error::into))
     }
 
@@ -218,7 +218,7 @@ pub struct SingleItemEncoder<'a> {
 
 impl<'a> SingleItemEncoder<'a> {
     /// Emit an arbitrary encodable object
-    pub fn emit<E: Encodable + ?Sized>(self, value: &E) -> Result<(), StructureError> {
+    pub fn emit<E: ToBencode + ?Sized>(self, value: &E) -> Result<(), StructureError> {
         value.encode(self).map_err(Error::into)
     }
 
@@ -283,7 +283,7 @@ impl<'a> SingleItemEncoder<'a> {
     /// the caller needs to ensure that the iterator has a defined order.
     pub fn emit_unchecked_list(
         self,
-        iterable: impl Iterator<Item = impl Encodable>,
+        iterable: impl Iterator<Item = impl ToBencode>,
     ) -> Result<(), StructureError> {
         self.emit_list(|e| {
             for item in iterable {
@@ -303,7 +303,7 @@ impl<'a> SortedDictEncoder<'a> {
     /// Emit a key/value pair
     pub fn emit_pair<E>(&mut self, key: &[u8], value: E) -> Result<(), StructureError>
     where
-        E: Encodable,
+        E: ToBencode,
     {
         self.encoder.emit_token(Token::String(key))?;
         self.encoder.emit(value)
@@ -333,7 +333,7 @@ impl UnsortedDictEncoder {
     /// Emit a key/value pair
     pub fn emit_pair<E>(&mut self, key: &[u8], value: E) -> Result<(), StructureError>
     where
-        E: Encodable,
+        E: ToBencode,
     {
         self.emit_pair_with(key, |e| value.encode(e).map_err(Error::into))
     }


### PR DESCRIPTION
Introduces the until now missing decoding interface which will be exported as `FromBencode` with an entry point named `from_bencode`.

It also uses the chance to rename the encoding trait from `Encodable` into `ToBencode` and `Encodable::to_bytes` into `FromBencode::to_bencode`.