### PR TITLE
Allow Custom Errors in State Tracker

### DIFF
--- a/src/decoding/error.rs
+++ b/src/decoding/error.rs
@@ -1,13 +1,13 @@
 use std::{
     fmt::{self, Display, Formatter},
-    num, str, string,
+    sync::Arc,
 };
 
 use failure::Fail;
 
 use crate::state_tracker::StructureError;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Clone, Fail)]
 pub struct Error {
     #[fail(context)]
     context: Option<String>,
@@ -16,16 +16,16 @@ pub struct Error {
 }
 
 /// An enumeration of potential errors that appear during bencode deserialization.
-#[derive(Debug, Fail)]
+#[derive(Debug, Clone, Fail)]
 pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid information.
     #[fail(display = "malformed content discovered: {}", _0)]
-    MalformedContent(failure::Error),
+    MalformedContent(Arc<failure::Error>),
     /// Error that occurs if the serialized structure is incomplete.
     #[fail(display = "missing field: {}", _0)]
     MissingField(String),
     /// Error in the bencode structure (e.g. a missing field end separator).
-    #[fail(display = "bencode encoding corrupted")]
+    #[fail(display = "bencode encoding corrupted ({})", _0)]
     StructureError(#[fail(cause)] StructureError),
     /// Error that occurs if the serialized structure contains an unexpected field.
     #[fail(display = "unexpected field: {}", _0)]
@@ -37,24 +37,6 @@ pub enum ErrorKind {
 
 pub trait ResultExt {
     fn context(self, context: impl std::fmt::Display) -> Self;
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match &self.context {
-            Some(context) => write!(f, "Error: {} in {}", self.error, context),
-            None => write!(f, "Error: {}", self.error),
-        }
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(error: ErrorKind) -> Self {
-        Error {
-            context: None,
-            error,
-        }
-    }
 }
 
 impl Error {
@@ -71,7 +53,8 @@ impl Error {
     /// Raised when there is a general error while deserializing a type.
     /// The message should not be capitalized and should not end with a period.
     pub fn malformed_content(cause: impl Into<failure::Error>) -> Error {
-        Self::from(ErrorKind::MalformedContent(cause.into()))
+        let error = Arc::new(cause.into());
+        Self::from(ErrorKind::MalformedContent(error))
     }
 
     /// Returns a `Error::MissingField` which contains the name of the field.
@@ -93,26 +76,32 @@ impl Error {
     }
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match &self.context {
+            Some(context) => write!(f, "Error: {} in {}", self.error, context),
+            None => write!(f, "Error: {}", self.error),
+        }
+    }
+}
+
 impl From<StructureError> for Error {
     fn from(error: StructureError) -> Self {
         Self::from(ErrorKind::StructureError(error))
     }
 }
 
-impl From<num::ParseIntError> for Error {
-    fn from(error: num::ParseIntError) -> Self {
-        Self::malformed_content(error)
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self {
+            context: None,
+            error: kind,
+        }
     }
 }
 
-impl From<str::Utf8Error> for Error {
-    fn from(error: str::Utf8Error) -> Self {
-        Self::malformed_content(error)
-    }
-}
-
-impl From<string::FromUtf8Error> for Error {
-    fn from(error: string::FromUtf8Error) -> Self {
+impl<T: std::error::Error + Send + Sync + 'static> From<T> for Error {
+    fn from(error: T) -> Self {
         Self::malformed_content(error)
     }
 }

--- a/src/decoding/from_bencode.rs
+++ b/src/decoding/from_bencode.rs
@@ -135,3 +135,48 @@ impl FromBencode for AsString<Vec<u8>> {
         object.try_into_bytes().map(Vec::from).map(AsString)
     }
 }
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use crate::encoding::AsString;
+
+    #[test]
+    fn from_bencode_to_string_should_work_with_valid_input() {
+        let expected_message = "hello";
+        let serialized_message =
+            format!("{}:{}", expected_message.len(), expected_message).into_bytes();
+
+        let decoded_message = String::from_bencode(&serialized_message).unwrap();
+        assert_eq!(expected_message, decoded_message);
+    }
+
+    #[test]
+    fn from_bencode_to_as_string_should_work_with_valid_input() {
+        let expected_message = "hello";
+        let serialized_message =
+            format!("{}:{}", expected_message.len(), expected_message).into_bytes();
+
+        let decoded_vector = AsString::from_bencode(&serialized_message).unwrap();
+        assert_eq!(expected_message.as_bytes(), &decoded_vector.0[..]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Num")]
+    fn from_bencode_to_as_string_should_fail_for_integer() {
+        AsString::<Vec<u8>>::from_bencode(&b"i1e"[..]).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NestingTooDeep")]
+    fn from_bencode_to_as_string_should_fail_for_list() {
+        AsString::<Vec<u8>>::from_bencode(&b"l1:ae"[..]).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NestingTooDeep")]
+    fn from_bencode_to_as_string_should_fail_for_dictionary() {
+        AsString::<Vec<u8>>::from_bencode(&b"d1:a1:ae"[..]).unwrap();
+    }
+}

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -111,7 +111,7 @@ mod to_bencode;
 
 pub use self::{
     encoder::{Encoder, SingleItemEncoder, SortedDictEncoder, UnsortedDictEncoder},
-    error::Error,
+    error::{Error, ErrorKind},
     printable_integer::PrintableInteger,
     to_bencode::{AsString, ToBencode},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! accept any sort of invalid encoding in any mode (including non-canonical encodings)
 //!
 //! The encoder is likewise designed to ensure that it only produces valid structures.
+
 pub mod decoding;
 pub mod encoding;
-
-mod state_tracker;
+pub mod state_tracker;

--- a/src/state_tracker.rs
+++ b/src/state_tracker.rs
@@ -3,6 +3,5 @@ mod state;
 mod structure_error;
 mod token;
 
-pub(crate) use self::{
-    stack::Stack, state::StateTracker, structure_error::StructureError, token::Token,
-};
+pub use self::token::Token;
+pub(crate) use self::{stack::Stack, state::StateTracker, structure_error::StructureError};


### PR DESCRIPTION
This will introduce a generic error type to the state tracker data structure and use this one to remove the internal `StructureError` from the public api. This allows us to use the new high level error types inside the encoding callbacks without the fear of losing information in case an implementation detail related error appears.