### PR TITLE
Add `no_std` support and introduce feature `std`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bendy"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 
 authors = [
@@ -10,7 +10,7 @@ authors = [
 ]
 
 description = """
-A rust library for encoding and decoding bencode with enforced cannonicalization rules.
+A rust library for encoding and decoding bencode with enforced canonicalization rules.
 """
 
 repository = "https://github.com/P3KI/bendy"
@@ -22,12 +22,13 @@ categories = ["encoding"]
 
 [badges]
 maintenance = {status = "actively-developed"}
+travis-ci = { repository = "P3KI/bendy" }
 
 [profile.release]
 lto = true
 
 [dependencies]
-failure = "^0.1.3"
+failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
 
 [dev-dependencies]
 regex = "^1.0"
@@ -35,3 +36,22 @@ skeptic = "^0.13"
 
 [build-dependencies]
 skeptic = "^0.13"
+
+### FEATURES #################################################################
+
+[features]
+default = ["std"]
+
+# Provide implementations for common standard library types like `Vec<T>` and
+# `HashMap<K, V>`. Requires a dependency on the Rust standard library.
+std = [ "failure/std" ]
+
+### Targets ##################################################################
+
+[[test]]
+name = "core_test"
+required-features = [ "std" ]
+
+[[example]]
+name = "encode_torrent"
+required-features = [ "std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "BSD-3-Clause"
 readme = "README.md"
 
 keywords = ["bencode", "serialization", "deserialization", "bittorent"]
-categories = ["encoding"]
+categories = ["encoding", "decoding", "no-std"]
 
 [badges]
 maintenance = {status = "actively-developed"}
@@ -26,16 +26,15 @@ travis-ci = { repository = "P3KI/bendy" }
 
 [profile.release]
 lto = true
+opt-level = 3
+codegen-units = 1
 
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
 
 [dev-dependencies]
 regex = "^1.0"
-skeptic = "^0.13"
-
-[build-dependencies]
-skeptic = "^0.13"
+doc-comment = "^0.3"
 
 ### FEATURES #################################################################
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ it is enough to import the trait and call the `to_bencode()` function on the obj
 ```rust
 use bendy::encoding::{ToBencode, Error};
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_vector() -> Result<(), Error> {
     let my_data = vec!["hello", "world"];
     let encoded = my_data.to_bencode()?;
 
@@ -137,7 +140,10 @@ impl ToBencode for IntegerWrapper {
     } 
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_integer() -> Result<(), Error> {
     let example = IntegerWrapper(21);
     
     let encoded = example.to_bencode()?;
@@ -168,7 +174,10 @@ impl ToBencode for StringWrapper {
     } 
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_string() -> Result<(), Error> {
     let example = StringWrapper("content".to_string());
 
     let encoded = example.to_bencode()?;
@@ -200,7 +209,10 @@ impl ToBencode for ByteStringWrapper {
     } 
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_byte_string() -> Result<(), Error> {
     let example = ByteStringWrapper(b"content".to_vec());
     
     let encoded = example.to_bencode()?;
@@ -246,7 +258,10 @@ impl ToBencode for Example {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_dictionary() -> Result<(), Error> {
     let example = Example { label: "Example".to_string(), counter: 0 };
     
     let encoded = example.to_bencode()?;
@@ -278,7 +293,10 @@ impl ToBencode for Location {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn encode_list() -> Result<(), Error> {
     let example = Location(2, 3);
 
     let encoded = example.to_bencode()?;
@@ -296,7 +314,10 @@ it is enough to import the trait and call the `from_bencode()` function on the o
 ```rust
 use bendy::decoding::{FromBencode, Error};
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn decode_vector() -> Result<(), Error> {
     let encoded = b"l5:hello5:worlde".to_vec();
     let decoded = Vec::<String>::from_bencode(&encoded)?;
     
@@ -352,7 +373,10 @@ impl FromBencode for IntegerWrapper {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn decode_integer() -> Result<(), Error> {
     let encoded = b"i21e".to_vec();
     
     let example = IntegerWrapper::from_bencode(&encoded)?;
@@ -390,7 +414,10 @@ impl FromBencode for StringWrapper {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn decode_string() -> Result<(), Error> {
     let encoded = b"7:content".to_vec();
     
     let example = StringWrapper::from_bencode(&encoded)?;
@@ -425,7 +452,10 @@ impl FromBencode for ByteStringWrapper {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn decode_byte_string() -> Result<(), Error> {
     let encoded = b"7:content".to_vec();
     
     let example = ByteStringWrapper::from_bencode(&encoded)?;
@@ -492,7 +522,10 @@ impl FromBencode for Example {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+#[test]
+fn decode_dictionary() -> Result<(), Error> {
     let encoded = b"d7:counteri0e5:label7:Examplee".to_vec();
     let expected = Example { label: "Example".to_string(), counter: 0 };
     
@@ -530,7 +563,9 @@ impl FromBencode for Location {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {}
+
+fn decode_list() -> Result<(), Error> {
     let encoded = b"li2ei3ee".to_vec();
     let expected = Location(2, 3);
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,9 @@
 unstable_features = true
 
-required_version = "1.0.3"
+required_version = "1.3.0"
 edition = "2018"
 
-format_doc_comments = true
+format_code_in_doc_comments = true
 match_block_trailing_comma = true
 merge_imports = true
 reorder_impl_items = true

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -4,10 +4,10 @@
 //! For any decoding process, first we need to create a decoder:
 //!
 //! ```
-//! # use bendy::decoding::{Error, Decoder,Object};
+//! # use bendy::decoding::{Decoder};
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
-//! let mut decoder = Decoder::new(buf);
+//! let _decoder = Decoder::new(buf);
 //! ```
 //!
 //! Decoders have a depth limit to prevent resource exhaustion from hostile inputs. By default, it's
@@ -16,12 +16,11 @@
 //! attacker can cause your program to use, so we recommend setting the bounds tightly:
 //!
 //! ```
-//! # use bendy::decoding::{Decoder,Object, Error};
+//! # use bendy::decoding::{Decoder};
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
-//! # let mut decoder = Decoder::new(buf);
-//! #
-//! decoder = decoder.with_max_depth(3);
+//! let _decoder = Decoder::new(buf)
+//!   .with_max_depth(3);
 //! ```
 //!
 //! Atoms (integers and strings) have depth zero, and lists and dicts have a depth equal to the
@@ -30,7 +29,7 @@
 //! Now, you can start reading objects:
 //!
 //! ```
-//! # use bendy::decoding::{Decoder,Object, Error};
+//! # use bendy::decoding::{Decoder,Object};
 //! #
 //! # fn decode_list(_: bendy::decoding::ListDecoder) {}
 //! # fn decode_dict(_: bendy::decoding::DictDecoder) {}
@@ -42,8 +41,8 @@
 //!     None => (), // EOF
 //!     Some(Object::List(d)) => decode_list(d),
 //!     Some(Object::Dict(d)) => decode_dict(d),
-//!     Some(Object::Integer(s)) => (), // integer, as a string
-//!     Some(Object::Bytes(b)) => (), // A raw bytestring
+//!     Some(Object::Integer(_)) => (), // integer, as a string
+//!     Some(Object::Bytes(_)) => (), // A raw bytestring
 //! };
 //! ```
 //!
@@ -61,6 +60,8 @@
 //!     decoder.next_object().ok(); // ignore the return value of this
 //!     return decoder.next_object().is_ok();
 //! }
+//! #
+//! # assert!(syntax_check(b"i18e"));
 //! ```
 mod decoder;
 mod error;

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -63,6 +63,7 @@
 //! #
 //! # assert!(syntax_check(b"i18e"));
 //! ```
+
 mod decoder;
 mod error;
 mod from_bencode;

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -1,3 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(not(feature = "std"))]
+use core::str;
+#[cfg(feature = "std")]
+use std::{format, str};
+
 use crate::{
     decoding::{Error, Object},
     state_tracker::{StateTracker, StructureError, Token},
@@ -54,7 +61,6 @@ impl<'ser> Decoder<'ser> {
     }
 
     fn take_int(&mut self, expected_terminator: char) -> Result<&'ser str, StructureError> {
-        use std::str;
         enum State {
             Start,
             Sign,
@@ -354,6 +360,13 @@ impl<'obj, 'ser: 'obj> Drop for ListDecoder<'obj, 'ser> {
 
 #[cfg(test)]
 mod test {
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, vec::Vec};
+    #[cfg(not(feature = "std"))]
+    use core::iter;
+
+    #[cfg(feature = "std")]
     use std::iter;
 
     use regex;

--- a/src/decoding/from_bencode.rs
+++ b/src/decoding/from_bencode.rs
@@ -1,3 +1,7 @@
+#[cfg(not(feature = "std"))]
+use alloc::{rc::Rc, string::String, vec::Vec};
+
+#[cfg(feature = "std")]
 use std::{
     collections::HashMap,
     hash::{BuildHasher, Hash},
@@ -88,6 +92,7 @@ impl FromBencode for String {
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, H> FromBencode for HashMap<K, V, H>
 where
     K: FromBencode + Hash + Eq,
@@ -139,8 +144,12 @@ impl FromBencode for AsString<Vec<u8>> {
 #[cfg(test)]
 mod test {
 
-    use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::{format, vec::Vec};
+
     use crate::encoding::AsString;
+
+    use super::*;
 
     #[test]
     fn from_bencode_to_string_should_work_with_valid_input() {

--- a/src/decoding/object.rs
+++ b/src/decoding/object.rs
@@ -100,7 +100,7 @@ impl<'obj, 'ser: 'obj> Object<'obj, 'ser> {
     /// # Examples
     ///
     /// ```
-    /// use bendy::decoding::{Error, Object};
+    /// use bendy::decoding::Object;
     ///
     /// let x = Object::Bytes(b"foo");
     /// assert_eq!(b"foo", x.try_into_bytes().unwrap());
@@ -190,7 +190,7 @@ impl<'obj, 'ser: 'obj> Object<'obj, 'ser> {
     /// # Examples
     ///
     /// ```
-    /// use bendy::decoding::{Error, Object};
+    /// use bendy::decoding::Object;
     ///
     /// let x = Object::Integer("123");
     /// assert_eq!("123", x.try_into_integer().unwrap());
@@ -282,7 +282,7 @@ impl<'obj, 'ser: 'obj> Object<'obj, 'ser> {
     /// # Examples
     ///
     /// ```
-    /// use bendy::decoding::{Decoder, Error, Object};
+    /// use bendy::decoding::{Decoder, Object};
     ///
     /// let mut list_decoder = Decoder::new(b"le");
     /// let x = list_decoder.next_object().unwrap().unwrap();
@@ -378,7 +378,7 @@ impl<'obj, 'ser: 'obj> Object<'obj, 'ser> {
     /// # Examples
     ///
     /// ```
-    /// use bendy::decoding::{Decoder, Error, Object};
+    /// use bendy::decoding::{Decoder, Object};
     ///
     /// let mut dict_decoder = Decoder::new(b"de");
     /// let x = dict_decoder.next_object().unwrap().unwrap();

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -26,6 +26,15 @@
 //!         Ok(())
 //!     }
 //! }
+//! #
+//! # fn main() -> Result<(), Error> {
+//! #    let message = Message{
+//! #      foo: 1,
+//! #      bar: "quux".to_string(),
+//! #    };
+//! #
+//! #   message.to_bencode().map(|_| ())
+//! # }
 //! ```
 //!
 //! Then, messages can be serialized using [`ToBencode::to_bencode`]:
@@ -53,13 +62,16 @@
 //! #         Ok(())
 //! #     }
 //! # }
-//! # let result: Result<Vec<u8>, Error> =
-//! Message{
-//!     foo: 1,
-//!     bar: "quux".to_string(),
-//! }.to_bencode()
-//! # ;
-//! # assert!(result.is_ok());
+//! #
+//! # fn main() -> Result<(), Error> {
+//!     let message = Message{
+//!       foo: 1,
+//!       bar: "quux".to_string(),
+//!     };
+//!
+//!     message.to_bencode()
+//! #    .map(|_| ())
+//! # }
 //! ```
 //!
 //! Most primitive types already implement [`ToBencode`].
@@ -78,15 +90,16 @@
 //! # use bendy::encoding::{ToBencode, Encoder, Error};
 //! #
 //! # type ObjectType = u32;
-//! # static object: u32 = 0;
+//! # static OBJECT: u32 = 0;
 //! #
 //! # fn main() -> Result<(), Error> {
-//! let mut encoder = Encoder::new()
-//!     .with_max_depth(ObjectType::MAX_DEPTH + 10);
-//! encoder.emit(object)?;
-//! encoder.get_output()
-//! #   .map_err(Error::from)
-//! #   .map(|_| ()) // ignore a success return value
+//!     let mut encoder = Encoder::new()
+//!       .with_max_depth(ObjectType::MAX_DEPTH + 10);
+//!
+//!     encoder.emit(OBJECT)?;
+//!     encoder.get_output()
+//! #     .map_err(Error::from)
+//! #     .map(|_| ()) // ignore a success return value
 //! # }
 //! ```
 //!

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -114,13 +114,15 @@ impl Encoder {
     /// Example:
     ///
     /// ```
-    /// # use bendy::encoding::Encoder;
+    /// # use bendy::encoding::{Encoder, Error};
     /// #
-    /// # let mut encoder = Encoder::new();
-    /// encoder.emit_dict(|mut e| {
-    ///     e.emit_pair(b"a", "foo")?;
-    ///     e.emit_pair(b"b", 2)
-    /// });
+    /// # fn main() -> Result<(), Error>{
+    ///     let mut encoder = Encoder::new();
+    ///     encoder.emit_dict(|mut e| {
+    ///       e.emit_pair(b"a", "foo")?;
+    ///       e.emit_pair(b"b", 2)
+    ///     })
+    /// # }
     /// ```
     pub fn emit_dict<F>(&mut self, content_cb: F) -> Result<(), Error>
     where
@@ -137,14 +139,15 @@ impl Encoder {
     /// E.g., to emit the list `[1,2,3]`, you would write
     ///
     /// ```
-    /// # use bendy::encoding::Encoder;
-    /// #
+    /// # use bendy::encoding::{Encoder, Error};
+    /// # fn main() -> Result<(), Error> {
     /// let mut encoder = Encoder::new();
     /// encoder.emit_list(|e| {
-    ///    e.emit_int(1)?;
-    ///    e.emit_int(2)?;
-    ///    e.emit_int(3)
-    /// });
+    ///     e.emit_int(1)?;
+    ///     e.emit_int(2)?;
+    ///     e.emit_int(3)
+    /// })
+    /// # }
     /// ```
     pub fn emit_list<F>(&mut self, list_cb: F) -> Result<(), Error>
     where
@@ -165,14 +168,12 @@ impl Encoder {
     /// # use bendy::encoding::{Encoder, Error};
     /// #
     /// # fn main() -> Result<(), Error> {
-    /// # let mut encoder = Encoder::new();
-    /// #
-    /// encoder.emit_and_sort_dict(|mut e| {
-    ///     // Unlike in the example for Encoder::emit_dict(), these keys aren't sorted
-    ///     e.emit_pair(b"b", 2)?;
-    ///     e.emit_pair(b"a", "foo")
-    /// })?;
-    /// Ok(())
+    ///     let mut encoder = Encoder::new();
+    ///     encoder.emit_and_sort_dict(|e| {
+    ///       // Unlike in the example for Encoder::emit_dict(), these keys aren't sorted
+    ///       e.emit_pair(b"b", 2)?;
+    ///       e.emit_pair(b"a", "foo")
+    ///     })
     /// # }
     /// ```
     pub fn emit_and_sort_dict<F>(&mut self, content_cb: F) -> Result<(), Error>

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use std::sync::Arc;
 
 use failure::Fail;
@@ -12,9 +13,13 @@ pub struct Error(#[fail(cause)] pub ErrorKind);
 #[derive(Debug, Clone, Fail)]
 pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid semantics.
+    #[cfg(feature = "std")]
     #[fail(display = "malformed content discovered: {}", _0)]
     MalformedContent(Arc<failure::Error>),
-
+    /// Error that occurs if the serialized structure contains invalid semantics.
+    #[cfg(not(feature = "std"))]
+    #[fail(display = "malformed content discovered")]
+    MalformedContent,
     /// Error in the bencode structure (e.g. a missing field end separator).
     #[fail(display = "bencode encoding corrupted")]
     StructureError(#[fail(cause)] StructureError),
@@ -23,6 +28,7 @@ pub enum ErrorKind {
 impl Error {
     /// Raised when there is a general error while deserializing a type.
     /// The message should not be capitalized and should not end with a period.
+    #[cfg(feature = "std")]
     pub fn malformed_content(cause: impl Into<failure::Error>) -> Error {
         let error = Arc::new(cause.into());
         Self(ErrorKind::MalformedContent(error))

--- a/src/encoding/printable_integer.rs
+++ b/src/encoding/printable_integer.rs
@@ -1,18 +1,14 @@
-use std::io::{self, Write};
+#[cfg(not(feature = "std"))]
+use core::fmt::Display;
+#[cfg(feature = "std")]
+use std::fmt::Display;
 
 /// A value that can be formatted as a decimal integer
-pub trait PrintableInteger {
-    /// Write the value as a decimal integer
-    fn write_to<W: Write>(self, w: W) -> io::Result<()>;
-}
+pub trait PrintableInteger: Display {}
 
 macro_rules! impl_integer {
     ($($type:ty)*) => {$(
-        impl PrintableInteger for $type {
-            fn write_to<W: Write>(self, mut w: W) -> io::Result<()> {
-                write!(w, "{}", self)
-            }
-        }
+        impl PrintableInteger for $type {}
     )*}
 }
 

--- a/src/encoding/to_bencode.rs
+++ b/src/encoding/to_bencode.rs
@@ -1,6 +1,18 @@
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::{BTreeMap, LinkedList, VecDeque},
+    rc::Rc,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
+
+#[cfg(feature = "std")]
 use std::{
     collections::{BTreeMap, HashMap, LinkedList, VecDeque},
-    hash::Hash,
+    hash::{BuildHasher, Hash},
+    rc::Rc,
+    sync::Arc,
 };
 
 use crate::encoding::{Encoder, Error, SingleItemEncoder};
@@ -37,6 +49,7 @@ impl<'a, E: 'a + ToBencode + Sized> ToBencode for &'a E {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: ToBencode> ToBencode for Box<E> {
     const MAX_DEPTH: usize = E::MAX_DEPTH;
 
@@ -45,7 +58,7 @@ impl<E: ToBencode> ToBencode for Box<E> {
     }
 }
 
-impl<E: ToBencode> ToBencode for ::std::rc::Rc<E> {
+impl<E: ToBencode> ToBencode for Rc<E> {
     const MAX_DEPTH: usize = E::MAX_DEPTH;
 
     fn encode(&self, encoder: SingleItemEncoder) -> Result<(), Error> {
@@ -53,7 +66,7 @@ impl<E: ToBencode> ToBencode for ::std::rc::Rc<E> {
     }
 }
 
-impl<E: ToBencode> ToBencode for ::std::sync::Arc<E> {
+impl<E: ToBencode> ToBencode for Arc<E> {
     const MAX_DEPTH: usize = E::MAX_DEPTH;
 
     fn encode(&self, encoder: SingleItemEncoder) -> Result<(), Error> {
@@ -149,11 +162,12 @@ impl<K: AsRef<[u8]>, V: ToBencode> ToBencode for BTreeMap<K, V> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, S> ToBencode for HashMap<K, V, S>
 where
     K: AsRef<[u8]> + Eq + Hash,
     V: ToBencode,
-    S: ::std::hash::BuildHasher,
+    S: BuildHasher,
 {
     const MAX_DEPTH: usize = V::MAX_DEPTH + 1;
 
@@ -206,6 +220,9 @@ where
 
 #[cfg(test)]
 mod test {
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{borrow::ToOwned, vec};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,11 @@
 //!
 //! The encoder is likewise designed to ensure that it only produces valid structures.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub mod decoding;
 pub mod encoding;
 pub mod state_tracker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,6 @@ extern crate alloc;
 pub mod decoding;
 pub mod encoding;
 pub mod state_tracker;
+
+#[cfg(test)]
+doc_comment::doctest!("../README.md");

--- a/src/state_tracker/stack.rs
+++ b/src/state_tracker/stack.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 pub trait Stack<T> {
     fn peek_mut(&mut self) -> Option<&mut T>;
 

--- a/src/state_tracker/state.rs
+++ b/src/state_tracker/state.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::state_tracker::{Stack, StructureError, Token};
 
 /// The state of current level of the decoder

--- a/src/state_tracker/structure_error.rs
+++ b/src/state_tracker/structure_error.rs
@@ -1,5 +1,14 @@
-use failure::Fail;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+#[cfg(not(feature = "std"))]
+use core::fmt::Display;
+#[cfg(feature = "std")]
 use std::fmt::Display;
+
+use failure::Fail;
 
 /// An encoding or decoding error
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Fail)]

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This introduces `no_std` support and a new default feature called  `std`. It also replaces `skeptic` as documentation testing dependency with the far more light weight `doc_comment`.

This has currently two known problems:

1) During the `doctest` build step the following error message appears. It seems like this based on an `doctest` internal problem and has now further consequences as even after the message is printed all tests run properly (related: https://github.com/rust-lang/rust/issues/54010, https://github.com/rust-lang/rust/issues/52243).

   ```error
      Doc-tests bendy
   error: no global memory allocator found but one is required; link to std or add #[global_allocator] to a    static item that implements the GlobalAlloc trait.

   error: aborting due to previous error
   ```
2) As soon as `doc_comment` is used with the `#[cfg(test)]` attribute it is not working as expected and won't run the doc tests. I assume that the reason here is rustdoc not using the test flag (https://github.com/rust-lang/rust/pull/61199). So this will not work until https://github.com/rust-lang/rust/pull/61351 and https://github.com/rust-lang/rust/pull/62213 are merged and we change it into `#[cfg(doctest)]`.