### PR TITLE
Task/make no std more ergonomic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,10 @@ matrix:
          - rustup target add thumbv7m-none-eabi
        script:
          - cargo build --all --no-default-features --target=thumbv7m-none-eabi
+     - name: "Rust 1.38 - Windows"
+       rust: 1.38.0
+       os: windows
+  exclude:
+     # backtrace on Windows requires 1.38
+     - os: windows
+       rust: 1.36.0

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-required_version = "1.4.6"
+required_version = "1.4.11"
 edition = "2018"
 
 format_code_in_doc_comments = true

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -19,8 +19,7 @@
 //! # use bendy::decoding::{Decoder};
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
-//! let _decoder = Decoder::new(buf)
-//!   .with_max_depth(3);
+//! let _decoder = Decoder::new(buf).with_max_depth(3);
 //! ```
 //!
 //! Atoms (integers and strings) have depth zero, and lists and dicts have a depth equal to the
@@ -42,7 +41,7 @@
 //!     Some(Object::List(d)) => decode_list(d),
 //!     Some(Object::Dict(d)) => decode_dict(d),
 //!     Some(Object::Integer(_)) => (), // integer, as a string
-//!     Some(Object::Bytes(_)) => (), // A raw bytestring
+//!     Some(Object::Bytes(_)) => (),   // A raw bytestring
 //! };
 //! ```
 //!

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -1,9 +1,5 @@
-#[cfg(not(feature = "std"))]
 use alloc::format;
-#[cfg(not(feature = "std"))]
 use core::str;
-#[cfg(feature = "std")]
-use std::{format, str};
 
 use crate::{
     decoding::{Error, Object},
@@ -363,11 +359,7 @@ mod test {
 
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
-    #[cfg(not(feature = "std"))]
     use core::iter;
-
-    #[cfg(feature = "std")]
-    use std::iter;
 
     use regex;
 

--- a/src/decoding/error.rs
+++ b/src/decoding/error.rs
@@ -1,20 +1,16 @@
 #[cfg(not(feature = "std"))]
+use alloc::{str::Utf8Error, string::FromUtf8Error};
+#[cfg(not(feature = "std"))]
+use core::num::ParseIntError;
+
 use alloc::{
     format,
-    string::{FromUtf8Error, String, ToString},
+    string::{String, ToString},
 };
-#[cfg(not(feature = "std"))]
-use core::{
-    fmt::{self, Display, Formatter},
-    num::ParseIntError,
-};
+use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "std")]
-use std::{
-    error::Error as StdError,
-    fmt::{self, Display, Formatter},
-    sync::Arc,
-};
+use std::{error::Error as StdError, sync::Arc};
 
 use failure::Fail;
 
@@ -76,6 +72,11 @@ impl Error {
         Self::from(ErrorKind::MalformedContent(error))
     }
 
+    #[cfg(not(feature = "std"))]
+    pub fn malformed_content<T>(_cause: T) -> Error {
+        Self::from(ErrorKind::MalformedContent)
+    }
+
     /// Returns a `Error::MissingField` which contains the name of the field.
     pub fn missing_field(field_name: impl Display) -> Error {
         Self::from(ErrorKind::MissingField(field_name.to_string()))
@@ -121,15 +122,22 @@ impl From<ErrorKind> for Error {
 
 #[cfg(not(feature = "std"))]
 impl From<FromUtf8Error> for Error {
-    fn from(_: FromUtf8Error) -> Self {
-        Self::from(ErrorKind::MalformedContent)
+    fn from(err: FromUtf8Error) -> Self {
+        Self::malformed_content(err)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl From<Utf8Error> for Error {
+    fn from(err: Utf8Error) -> Self {
+        Self::malformed_content(err)
     }
 }
 
 #[cfg(not(feature = "std"))]
 impl From<ParseIntError> for Error {
-    fn from(_: ParseIntError) -> Self {
-        Self::from(ErrorKind::MalformedContent)
+    fn from(err: ParseIntError) -> Self {
+        Self::malformed_content(err)
     }
 }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -64,12 +64,12 @@
 //! # }
 //! #
 //! # fn main() -> Result<(), Error> {
-//!     let message = Message{
-//!       foo: 1,
-//!       bar: "quux".to_string(),
-//!     };
+//! let message = Message {
+//!     foo: 1,
+//!     bar: "quux".to_string(),
+//! };
 //!
-//!     message.to_bencode()
+//! message.to_bencode()
 //! #    .map(|_| ())
 //! # }
 //! ```
@@ -93,11 +93,10 @@
 //! # static OBJECT: u32 = 0;
 //! #
 //! # fn main() -> Result<(), Error> {
-//!     let mut encoder = Encoder::new()
-//!       .with_max_depth(ObjectType::MAX_DEPTH + 10);
+//! let mut encoder = Encoder::new().with_max_depth(ObjectType::MAX_DEPTH + 10);
 //!
-//!     encoder.emit(OBJECT)?;
-//!     encoder.get_output()
+//! encoder.emit(OBJECT)?;
+//! encoder.get_output()
 //! #     .map_err(Error::from)
 //! #     .map(|_| ()) // ignore a success return value
 //! # }

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -128,11 +128,11 @@ impl Encoder {
     /// # use bendy::encoding::{Encoder, Error};
     /// #
     /// # fn main() -> Result<(), Error>{
-    ///     let mut encoder = Encoder::new();
-    ///     encoder.emit_dict(|mut e| {
-    ///       e.emit_pair(b"a", "foo")?;
-    ///       e.emit_pair(b"b", 2)
-    ///     })
+    /// let mut encoder = Encoder::new();
+    /// encoder.emit_dict(|mut e| {
+    ///     e.emit_pair(b"a", "foo")?;
+    ///     e.emit_pair(b"b", 2)
+    /// })
     /// # }
     /// ```
     pub fn emit_dict<F>(&mut self, content_cb: F) -> Result<(), Error>
@@ -179,12 +179,12 @@ impl Encoder {
     /// # use bendy::encoding::{Encoder, Error};
     /// #
     /// # fn main() -> Result<(), Error> {
-    ///     let mut encoder = Encoder::new();
-    ///     encoder.emit_and_sort_dict(|e| {
-    ///       // Unlike in the example for Encoder::emit_dict(), these keys aren't sorted
-    ///       e.emit_pair(b"b", 2)?;
-    ///       e.emit_pair(b"a", "foo")
-    ///     })
+    /// let mut encoder = Encoder::new();
+    /// encoder.emit_and_sort_dict(|e| {
+    ///     // Unlike in the example for Encoder::emit_dict(), these keys aren't sorted
+    ///     e.emit_pair(b"b", 2)?;
+    ///     e.emit_pair(b"a", "foo")
+    /// })
     /// # }
     /// ```
     pub fn emit_and_sort_dict<F>(&mut self, content_cb: F) -> Result<(), Error>

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -28,10 +28,18 @@ pub enum ErrorKind {
 impl Error {
     /// Raised when there is a general error while deserializing a type.
     /// The message should not be capitalized and should not end with a period.
+    ///
+    /// Note that, when building with no_std, this method accepts any type as
+    /// its argument.
     #[cfg(feature = "std")]
     pub fn malformed_content(cause: impl Into<failure::Error>) -> Error {
         let error = Arc::new(cause.into());
         Self(ErrorKind::MalformedContent(error))
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn malformed_content<T>(_cause: T) -> Error {
+        Self(ErrorKind::MalformedContent)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 pub mod decoding;


### PR DESCRIPTION
 Miscellaneous changes to make `no_std` usage more ergonomic

Specifically:

* `decode::Error::malformed_content` now exists without `std`, but has a  more permissive type constraint, and it simply ignores its argument
* Added a new conversion from `Utf8Error` to `decode::Error`

These changes help ensure that the same code can be used whether bendy is built with or without support for `std`.

