### PR TITLE
Add EditorConfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# Text is UTF-8
+charset = utf-8
+# Unix-style newlines
+end_of_line = lf
+# Newline ending every file
+insert_final_newline = true
+# Soft tabs
+indent_style = space
+# Two-space indentation
+indent_size = 4
+# Trim trailing whitespace
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 # Soft tabs
 indent_style = space
-# Two-space indentation
+# Four-space indentation
 indent_size = 4
 # Trim trailing whitespace
 trim_trailing_whitespace = true


### PR DESCRIPTION
EditorConfig is a widely-supported method to set project-wide defaults for editors:
https://editorconfig.org/

I have my text editor configured to use two-space tabs by default, so it's useful to
have an editor config file present with the project defaults, if the project uses another
tab size.

I don't think there are any particular downsides to including an editor config file,
but I can certainly understand if you'd rather not add more clutter to the repo.