### PR TITLE
Add `must_use` attribute to `Encoder::with_max_depth`

### DIFF
--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -29,6 +29,7 @@ impl Encoder {
     }
 
     /// Set the max depth of the encoded object
+    #[must_use]
     pub fn with_max_depth(mut self, max_depth: usize) -> Self {
         self.state.set_max_depth(max_depth);
         self


### PR DESCRIPTION
I mistook this function for a mutating setter, so I added a `must_use` attribute, which would have caught that mistake.