### PR TITLE
Add `Value` type holding arbitrary decoded bencoded values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 script:
   - cargo test --all
   - cargo test --all --no-default-features
-  - cargo test --all --features serde_support
+  - cargo test --all --features serde
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 script:
   - cargo test --all
   - cargo test --all --no-default-features
+  - cargo test --all features serde
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 script:
   - cargo test --all
   - cargo test --all --no-default-features
-  - cargo test --all --features serde
+  - cargo test --all --features serde_support
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 script:
   - cargo test --all
   - cargo test --all --no-default-features
-  - cargo test --all features serde
+  - cargo test --all --features serde
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ codegen-units = 1
 
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
-serde = { version = "^1.0" , package = "serde", optional = true }
-serde_bytes = "^0.11.3" # TODO: make this optional
+serde = { version = "^1.0" ,  optional = true }
+serde_bytes = { version = "^0.11.3", optional = true }
 
 [dev-dependencies]
 regex = "^1.0"
@@ -48,6 +48,8 @@ default = ["std"]
 # Provide implementations for common standard library types like `Vec<T>` and
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
 std = ["failure/std"]
+
+serde_support = ["serde", "serde_bytes"]
 
 ### Targets ####################################################################
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ default = ["std"]
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
 std = ["failure/std"]
 
+# Provide serde serialize and deserialize support
 serde_support = ["serde", "serde_bytes"]
 
 ### Targets ####################################################################

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ codegen-units = 1
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
 serde = { version = "^1.0" ,  optional = true }
-serde_bytes = { version = "^0.11.3", optional = true }
+
+[target.'cfg(feature = "serde")'.dependencies]
+serde_bytes = "^0.11.3"
 
 [dev-dependencies]
 regex = "^1.0"
@@ -48,9 +50,6 @@ default = ["std"]
 # Provide implementations for common standard library types like `Vec<T>` and
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
 std = ["failure/std"]
-
-# Provide serde serialize and deserialize support
-serde_support = ["serde", "serde_bytes"]
 
 ### Targets ####################################################################
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,8 @@ codegen-units = 1
 
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
-serde = { version = "^1.0" ,  optional = true }
-
-[target.'cfg(feature = "serde")'.dependencies]
-serde_bytes = "^0.11.3"
+serde = { version = "^1.0" ,  optional = true}
+serde_bytes = { version = "^0.11.3", optional = true }
 
 [dev-dependencies]
 regex = "^1.0"
@@ -50,6 +48,9 @@ default = ["std"]
 # Provide implementations for common standard library types like `Vec<T>` and
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
 std = ["failure/std"]
+
+# Support serde serialization to and deserialization from bencode
+serde_support = ["serde", "serde_bytes"]
 
 ### Targets ####################################################################
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ codegen-units = 1
 
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
-serde = { version = "^1.0" ,  optional = true}
+serde_ = { version = "^1.0" ,  optional = true, package = "serde" }
 serde_bytes = { version = "^0.11.3", optional = true }
 
 [dev-dependencies]
@@ -50,7 +50,7 @@ default = ["std"]
 std = ["failure/std"]
 
 # Support serde serialization to and deserialization from bencode
-serde_support = ["serde", "serde_bytes"]
+serde = ["serde_", "serde_bytes"]
 
 ### Targets ####################################################################
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ codegen-units = 1
 [dependencies]
 failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
 serde = { version = "^1.0" , package = "serde", optional = true }
+serde_bytes = "^0.11.3" # TODO: make this optional
 
 [dev-dependencies]
 regex = "^1.0"
 serde_derive = "^1.0"
-serde_bytes = "^0.11.3"
 
 ### FEATURES ###################################################################
 

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -407,7 +407,7 @@ impl UnsortedDictEncoder {
         self.save_pair(key, encoded_object)
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_support")]
     pub(crate) fn remaining_depth(&self) -> usize {
         self.remaining_depth
     }

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -407,7 +407,7 @@ impl UnsortedDictEncoder {
         self.save_pair(key, encoded_object)
     }
 
-    #[cfg(feature = "serde_support")]
+    #[cfg(feature = "serde")]
     pub(crate) fn remaining_depth(&self) -> usize {
         self.remaining_depth
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 extern crate alloc;
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(test, feature = "serde_support"))]
 #[macro_use]
 mod assert_matches;
 
@@ -17,7 +17,7 @@ pub mod decoding;
 pub mod encoding;
 pub mod state_tracker;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_support")]
 pub mod serde;
 
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,5 @@ pub mod state_tracker;
 
 #[cfg(feature = "serde")]
 pub mod serde;
+
+pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 extern crate alloc;
 
-#[cfg(all(test, feature = "serde_support"))]
+#[cfg(all(test, feature = "serde"))]
 #[macro_use]
 mod assert_matches;
 
@@ -17,7 +17,7 @@ pub mod decoding;
 pub mod encoding;
 pub mod state_tracker;
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 pub mod serde;
 
 pub mod value;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -52,8 +52,10 @@
 /// repr(-15, "i-15e");
 /// repr(1.0f32, b"4:\x3F\x80\x00\x00");
 /// repr(1.0f64, b"8:\x3F\xF0\x00\x00\x00\x00\x00\x00");
+///
+/// let none: Option<i32> = None;
+/// repr(none, "le");
 /// repr(Some(0), "li0ee");
-/// repr(<Option<i32>>::None, "le");
 ///
 /// let mut map = HashMap::new();
 /// map.insert("foo", 1);
@@ -229,8 +231,8 @@ mod tests {
 
     #[test]
     fn f32() {
-        let value = 100f32;
-        let bytes = value.to_be_bytes();
+        let value = 100.100f32;
+        let bytes = value.to_bits().to_be_bytes();
         let mut bencode: Vec<u8> = Vec::new();
         bencode.extend(b"4:");
         bencode.extend(&bytes);
@@ -239,8 +241,8 @@ mod tests {
 
     #[test]
     fn f64() {
-        let value = 100f64;
-        let bytes = value.to_be_bytes();
+        let value = 100.100f64;
+        let bytes = value.to_bits().to_be_bytes();
         let mut bencode: Vec<u8> = Vec::new();
         bencode.extend(b"8:");
         bencode.extend(&bytes);
@@ -434,7 +436,7 @@ mod tests {
     fn invalid_bool() {
         assert_matches!(
             from_bytes::<bool>(b"i100e"),
-            Err(Error::InvalidBool(value)) if value == "100"
+            Err(Error::InvalidBool(ref value)) if value == "100"
         );
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -31,6 +31,14 @@
 //! Bencode dictionary keys may only be byte strings. For this reason, map types with
 //! keys that do not serialize as byte strings are unsupported.
 //!
+//! Note that values of type `f32` and `f64` do not conform to bencode's canonical
+//! representation rules. For example, both `f32` and `f64` support negative zero
+//! values which have different bit patterns, but which represent the same logical
+//! value as positive zero.
+//!
+//! If you require bencoded values to have canonical representations, then it is best
+//! to avoid floating point values.
+//!
 //! Example Representations
 //! -----------------------
 /// ```

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -5,9 +5,9 @@
 //! - `true`: The integer value `1`.
 //! - `false`: The integer value `0`.
 //! - `char`: A string containing the UTF-8 encoding of the value.
-//! - `f32`: Represented as a length-four bencode byte string containing the little-
+//! - `f32`: Represented as a length-four bencode byte string containing the big-
 //!   endian order bytes of the IEEE-754 representation of the value.
-//! - `f64`: Represented as a length-eight bencode byte string containing the little-
+//! - `f64`: Represented as a length-eight bencode byte string containing the big-
 //!   endian order bytes of the IEEE-754 representation of the value.
 //! - `()`: Represented as the empty bencode list, `le`.
 //! - `Some(t)`: Represented as a list containing the bencoding of `t`.
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn f32() {
         let value = 100f32;
-        let bytes = value.to_le_bytes();
+        let bytes = value.to_be_bytes();
         let mut bencode: Vec<u8> = Vec::new();
         bencode.extend(b"4:");
         bencode.extend(&bytes);
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn f64() {
         let value = 100f64;
-        let bytes = value.to_le_bytes();
+        let bytes = value.to_be_bytes();
         let mut bencode: Vec<u8> = Vec::new();
         bencode.extend(b"8:");
         bencode.extend(&bytes);

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -44,6 +44,7 @@
 /// ```
 /// use bendy::serde::to_bytes;
 /// use serde::Serialize;
+/// use serde_ as serde;
 /// use serde_derive::Serialize;
 /// use std::collections::HashMap;
 ///
@@ -70,18 +71,22 @@
 /// map.insert("bar", 2);
 /// repr(map, "d3:bari2e3:fooi1ee");
 ///
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// struct Unit;
 /// repr(Unit, "le");
 ///
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// struct Newtype(String);
 /// repr(Newtype("foo".into()), "3:foo");
 ///
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// struct Tuple(bool, i32);
 /// repr(Tuple(false, 100), "li0ei100ee");
 ///
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// struct Record {
 ///     a: String,
@@ -96,6 +101,7 @@
 ///     "d1:a5:hello1:bi0ee",
 /// );
 ///
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// enum Enum {
 ///     Unit,
@@ -110,6 +116,7 @@
 /// repr(Enum::Struct { a: 'x', b: true }, "d6:Structd1:a1:x1:bi1eee");
 ///
 /// #[serde(untagged)]
+/// #[serde(crate = "serde_")]
 /// #[derive(Serialize)]
 /// enum Untagged {
 ///     Foo { x: i32 },
@@ -133,7 +140,7 @@ pub use ser::{to_bytes, Serializer};
 mod tests {
     use super::common::*;
 
-    use std::collections::HashMap;
+    use std::{collections::HashMap, fmt::Debug};
 
     use super::{de::from_bytes, ser::to_bytes};
 
@@ -297,6 +304,7 @@ mod tests {
     #[test]
     fn bytes_with_serde_bytes() {
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(crate = "serde_")]
         #[serde(transparent)]
         struct Owned {
             #[serde(with = "serde_bytes")]
@@ -311,6 +319,7 @@ mod tests {
         );
 
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(crate = "serde_")]
         #[serde(transparent)]
         struct Borrowed<'bytes> {
             #[serde(with = "serde_bytes")]
@@ -339,6 +348,7 @@ mod tests {
     #[test]
     fn unit_struct() {
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Foo;
         case(Foo, "le");
     }
@@ -346,6 +356,7 @@ mod tests {
     #[test]
     fn newtype_struct() {
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Foo(u8);
         case(Foo(1), "i1e");
     }
@@ -358,6 +369,7 @@ mod tests {
     #[test]
     fn tuple_struct() {
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Foo(String, u32, i32);
 
         case(Foo("hello".to_string(), 1, -100), "l5:helloi1ei-100ee");
@@ -366,6 +378,7 @@ mod tests {
     #[test]
     fn record_struct() {
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Foo {
             a: u8,
             b: String,
@@ -387,6 +400,7 @@ mod tests {
         // error if the struct serializer failed to correctly order
         // the fields during serialization.
         #[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+        #[serde(crate = "serde_")]
         struct Foo {
             fac: u8,
             fb: u8,
@@ -398,6 +412,7 @@ mod tests {
     #[test]
     fn enum_tests() {
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         enum Enum {
             Unit,
             Newtype(i32),
@@ -415,6 +430,7 @@ mod tests {
     fn untagged_enum() {
         #[serde(untagged)]
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         enum Untagged {
             Foo { x: i32 },
             Bar { y: String },
@@ -427,12 +443,14 @@ mod tests {
     #[test]
     fn flatten() {
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Foo {
             #[serde(flatten)]
             bar: Bar,
         }
 
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[serde(crate = "serde_")]
         struct Bar {
             x: i32,
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,21 +1,114 @@
 //! Serde bencode serialization and deserialization.
 //!
-//! The Serde data model contains a number of types which have no native bencode
-//! representation. Serializing and deserializing these types is currently
-//! unsupported:
-//! - `()`
-//! - `HashMap` and `BTreeMap`
-//! - `Option`
-//! - `bool`
-//! - `char`
-//! - `f32` and `f64`
-//! - enums
-//! - unit structs
+//! Rust types and values are represented in bencode as follows:
 //!
-//! In addition, the current implementation is not self-describing, so
-//! deserialization relying on  `serde::de::Deserializer::deserialize_any` is
-//! unsupported.
-
+//! - `true`: The integer value `1`.
+//! - `false`: The integer value `0`.
+//! - `char`: A string containing the UTF-8 encoding of the value.
+//! - `f32`: Represented as a length-four bencode byte string containing the little-
+//!   endian order bytes of the IEEE-754 representation of the value.
+//! - `f64`: Represented as a length-eight bencode byte string containing the little-
+//!   endian order bytes of the IEEE-754 representation of the value.
+//! - `()`: Represented as the empty bencode list, `le`.
+//! - `Some(t)`: Represented as a list containing the bencoding of `t`.
+//! - `None`: Represented as the empty list.
+//! - maps, including BTreeMap and HashMap: bencoded dictionaries.
+//! - record structs: Represented as bencoded dictionaries with the fields of the
+//!   struct represented as UTF-8 keys mapped to the bencoded serializations of the
+//!   values.
+//! - tuple structs: Represented as bencoded lists containing the serialized values
+//!   of the fields.
+//! - unit structs: Represented as the empty bencode list, `le`.
+//! - enum unit variants: Represented as a string containing the name of the variant,
+//! - enum newtype variants: Represented as a dict mapping the name of the variant
+//!   to the value the variant contains.
+//! - enum tuple variants: Represented as a dict mapping the name of the variant
+//!   to a list containing the fields of the enum.
+//! - enum struct variants: Represented as a dict mapping the name of the variant
+//!   to the struct representation of the fields of the variant.
+//! - untagged enums: Repesented as the variant value without any surrounding dictionary.
+//!
+//! Bencode dictionary keys may only be byte strings. For this reason, map types with
+//! keys that do not serialize as byte strings are unsupported.
+//!
+//! Example Representations
+//! -----------------------
+/// ```
+/// use bendy::serde::to_bytes;
+/// use serde::Serialize;
+/// use serde_derive::Serialize;
+/// use std::collections::HashMap;
+///
+/// fn repr(value: impl Serialize, bencode: impl AsRef<[u8]>) {
+///     assert_eq!(to_bytes(&value).unwrap(), bencode.as_ref());
+/// }
+///
+/// repr(true, "i1e");
+/// repr(false, "i0e");
+/// repr((), "le");
+/// repr('a', "1:a");
+/// repr('Å', b"2:\xC3\x85");
+/// repr(0, "i0e");
+/// repr(-15, "i-15e");
+/// repr(1.0f32, b"4:\x00\x00\x80\x3F");
+/// repr(1.0f64, b"8:\x00\x00\x00\x00\x00\x00\xF0\x3F");
+/// repr(Some(0), "li0ee");
+/// repr(<Option<i32>>::None, "le");
+///
+/// let mut map = HashMap::new();
+/// map.insert("foo", 1);
+/// map.insert("bar", 2);
+/// repr(map, "d3:bari2e3:fooi1ee");
+///
+/// #[derive(Serialize)]
+/// struct Unit;
+/// repr(Unit, "le");
+///
+/// #[derive(Serialize)]
+/// struct Newtype(String);
+/// repr(Newtype("foo".into()), "3:foo");
+///
+/// #[derive(Serialize)]
+/// struct Tuple(bool, i32);
+/// repr(Tuple(false, 100), "li0ei100ee");
+///
+/// #[derive(Serialize)]
+/// struct Record {
+///     a: String,
+///     b: bool,
+/// }
+///
+/// repr(
+///     Record {
+///         a: "hello".into(),
+///         b: false,
+///     },
+///     "d1:a5:hello1:bi0ee",
+/// );
+///
+/// #[derive(Serialize)]
+/// enum Enum {
+///     Unit,
+///     Newtype(i32),
+///     Tuple(bool, i32),
+///     Struct { a: char, b: bool },
+/// }
+///
+/// repr(Enum::Unit, "4:Unit");
+/// repr(Enum::Newtype(-1), "d7:Newtypei-1ee");
+/// repr(Enum::Tuple(true, 10), "d5:Tupleli1ei10eee");
+/// repr(Enum::Struct { a: 'x', b: true }, "d6:Structd1:a1:x1:bi1eee");
+///
+/// #[serde(untagged)]
+/// #[derive(Serialize)]
+/// enum Untagged {
+///     Foo { x: i32 },
+///     Bar { y: char },
+/// }
+///
+/// repr(Untagged::Foo { x: -1 }, "d1:xi-1ee");
+/// repr(Untagged::Bar { y: 'z' }, "d1:y1:ze");
+/// ```
 mod common;
 
 pub mod de;
@@ -30,7 +123,7 @@ pub use ser::{to_bytes, Serializer};
 mod tests {
     use super::common::*;
 
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
 
     use super::{de::from_bytes, ser::to_bytes};
 
@@ -100,6 +193,8 @@ mod tests {
 
     #[test]
     fn scalar() {
+        case(false, "i0e");
+        case(true, "i1e");
         case(0u8, "i0e");
         case(1u8, "i1e");
         case(0u16, "i0e");
@@ -130,6 +225,47 @@ mod tests {
         case(0isize, "i0e");
         case(1isize, "i1e");
         case(-1isize, "i-1e");
+    }
+
+    #[test]
+    fn f32() {
+        let value = 100f32;
+        let bytes = value.to_le_bytes();
+        let mut bencode: Vec<u8> = Vec::new();
+        bencode.extend(b"4:");
+        bencode.extend(&bytes);
+        case(value, bencode);
+    }
+
+    #[test]
+    fn f64() {
+        let value = 100f64;
+        let bytes = value.to_le_bytes();
+        let mut bencode: Vec<u8> = Vec::new();
+        bencode.extend(b"8:");
+        bencode.extend(&bytes);
+        case(value, bencode);
+    }
+
+    #[test]
+    fn unit() {
+        case((), "le");
+    }
+
+    #[test]
+    fn none() {
+        case::<Option<u8>, &str>(None, "le");
+    }
+
+    #[test]
+    fn some() {
+        case(Some(0), "li0ee");
+    }
+
+    #[test]
+    fn char() {
+        case('a', "1:a");
+        case('\u{1F9D0}', "4:\u{1F9D0}");
     }
 
     #[test]
@@ -175,6 +311,29 @@ mod tests {
     }
 
     #[test]
+    fn map() {
+        let mut map = HashMap::new();
+        map.insert("foo".to_owned(), 1);
+        map.insert("bar".to_owned(), 2);
+        case(map, "d3:bari2e3:fooi1ee");
+    }
+
+    #[test]
+    fn map_non_byte_key() {
+        let mut map = HashMap::new();
+        map.insert(1, 1);
+        map.insert(2, 2);
+        assert_matches!(to_bytes(&map), Err(Error::ArbitraryMapKeysUnsupported));
+    }
+
+    #[test]
+    fn unit_struct() {
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Foo;
+        case(Foo, "le");
+    }
+
+    #[test]
     fn newtype_struct() {
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
         struct Foo(u8);
@@ -195,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn struct_test() {
+    fn record_struct() {
         #[derive(Serialize, Deserialize, Debug, PartialEq)]
         struct Foo {
             a: u8,
@@ -227,125 +386,70 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_bool_serialize() {
-        assert_matches!(to_bytes(&true), Err(Error::UnsupportedType("bool")));
-    }
-
-    #[test]
-    fn unsupported_bool_deserialize() {
-        assert_matches!(from_bytes::<bool>(b""), Err(Error::UnsupportedType("bool")));
-    }
-
-    #[test]
-    fn unsupported_f32_deserialize() {
-        assert_matches!(from_bytes::<f32>(b""), Err(Error::UnsupportedType("f32")));
-    }
-
-    #[test]
-    fn unsupported_f32_serialize() {
-        assert_matches!(to_bytes(&0f32), Err(Error::UnsupportedType("f32")));
-    }
-
-    #[test]
-    fn unsupported_f64_deserialize() {
-        assert_matches!(from_bytes::<f64>(b""), Err(Error::UnsupportedType("f64")));
-    }
-
-    #[test]
-    fn unsupported_f64_serialize() {
-        assert_matches!(to_bytes(&0f64), Err(Error::UnsupportedType("f64")));
-    }
-
-    #[test]
-    fn unsupported_option_deserialize() {
-        assert_matches!(
-            from_bytes::<Option<u8>>(b""),
-            Err(Error::UnsupportedType("Option"))
-        );
-    }
-
-    #[test]
-    fn unsupported_some_serialize() {
-        assert_matches!(to_bytes(&Some(0)), Err(Error::UnsupportedType("Option")));
-    }
-
-    #[test]
-    fn unsupported_none_serialize() {
-        assert_matches!(
-            to_bytes::<Option<u8>>(&None),
-            Err(Error::UnsupportedType("Option"))
-        );
-    }
-
-    #[test]
-    fn unsupported_unit_deserialize() {
-        assert_matches!(from_bytes::<()>(b""), Err(Error::UnsupportedType("()")));
-    }
-
-    #[test]
-    fn unsupported_unit_serialize() {
-        assert_matches!(to_bytes(&()), Err(Error::UnsupportedType("()")));
-    }
-
-    #[test]
-    fn unsupported_unit_struct_deserialize() {
-        #[derive(Deserialize, Debug)]
-        struct Foo;
-        assert_matches!(
-            from_bytes::<Foo>(b""),
-            Err(Error::UnsupportedType("unit struct"))
-        );
-    }
-
-    #[test]
-    fn unsupported_unit_struct_serialize() {
-        #[derive(Serialize)]
-        struct Foo;
-        assert_matches!(to_bytes(&Foo), Err(Error::UnsupportedType("unit struct")));
-    }
-
-    #[test]
-    fn unsupported_char_deserialize() {
-        assert_matches!(from_bytes::<char>(b""), Err(Error::UnsupportedType("char")));
-    }
-
-    #[test]
-    fn unsupported_char_serialize() {
-        assert_matches!(to_bytes(&'a'), Err(Error::UnsupportedType("char")));
-    }
-
-    #[test]
-    fn unsupported_map_deserialize() {
-        assert_matches!(
-            from_bytes::<BTreeMap<u8, u8>>(b""),
-            Err(Error::UnsupportedType("map"))
-        );
-    }
-
-    #[test]
-    fn unsupported_map_serialize() {
-        let map: BTreeMap<u8, u8> = BTreeMap::new();
-        assert_matches!(to_bytes(&map), Err(Error::UnsupportedType("map")));
-    }
-
-    #[test]
-    fn unsupported_enum_deserialize() {
-        #[derive(Deserialize, Debug)]
-        enum Foo {}
-        assert_matches!(from_bytes::<Foo>(b""), Err(Error::UnsupportedType("enum")));
-    }
-
-    #[test]
-    fn unsupported_any_deserialize() {
-        #[serde(untagged)]
-        #[derive(Deserialize, Debug)]
-        pub(crate) enum Foo {
-            A { _x: char },
-            B { _x: String },
+    fn enum_tests() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        enum Enum {
+            Unit,
+            Newtype(i32),
+            Tuple(bool, i32),
+            Struct { a: char, b: bool },
         }
+
+        case(Enum::Unit, "4:Unit");
+        case(Enum::Newtype(-1), "d7:Newtypei-1ee");
+        case(Enum::Tuple(true, 10), "d5:Tupleli1ei10eee");
+        case(Enum::Struct { a: 'x', b: true }, "d6:Structd1:a1:x1:bi1eee");
+    }
+
+    #[test]
+    fn untagged_enum() {
+        #[serde(untagged)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        enum Untagged {
+            Foo { x: i32 },
+            Bar { y: String },
+        }
+
+        case(Untagged::Foo { x: -1 }, "d1:xi-1ee");
+        case(Untagged::Bar { y: "z".into() }, "d1:y1:ze");
+    }
+
+    #[test]
+    fn flatten() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Foo {
+            #[serde(flatten)]
+            bar: Bar,
+        }
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Bar {
+            x: i32,
+        }
+
+        case(Foo { bar: Bar { x: 1 } }, "d1:xi1ee");
+    }
+
+    #[test]
+    fn invalid_bool() {
         assert_matches!(
-            from_bytes::<Foo>(b""),
-            Err(Error::UnsupportedSelfDescribing)
+            from_bytes::<bool>(b"i100e"),
+            Err(Error::InvalidBool(value)) if value == "100"
         );
+    }
+
+    #[test]
+    fn invalid_f32() {
+        assert_matches!(from_bytes::<f32>(b"8:10000000"), Err(Error::InvalidF32(8)));
+    }
+
+    #[test]
+    fn invalid_f64() {
+        assert_matches!(from_bytes::<f64>(b"4:1000"), Err(Error::InvalidF64(4)));
+    }
+
+    #[test]
+    fn invalid_char() {
+        assert_matches!(from_bytes::<char>(b"2:00"), Err(Error::InvalidChar(2)));
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -50,8 +50,8 @@
 /// repr('Å', b"2:\xC3\x85");
 /// repr(0, "i0e");
 /// repr(-15, "i-15e");
-/// repr(1.0f32, b"4:\x00\x00\x80\x3F");
-/// repr(1.0f64, b"8:\x00\x00\x00\x00\x00\x00\xF0\x3F");
+/// repr(1.0f32, b"4:\x3F\x80\x00\x00");
+/// repr(1.0f64, b"8:\x3F\xF0\x00\x00\x00\x00\x00\x00");
 /// repr(Some(0), "li0ee");
 /// repr(<Option<i32>>::None, "le");
 ///

--- a/src/serde/common.rs
+++ b/src/serde/common.rs
@@ -1,11 +1,13 @@
 /// Standard library
 pub(crate) use std::{
     convert::TryInto,
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Display, Formatter},
     iter::Peekable,
     num::ParseIntError,
     str::{self, Utf8Error},
 };
+
+pub(crate) use serde_ as serde;
 
 /// Dependencies
 pub(crate) use serde::{

--- a/src/serde/common.rs
+++ b/src/serde/common.rs
@@ -1,5 +1,6 @@
 /// Standard library
 pub(crate) use std::{
+    convert::TryInto,
     fmt::{self, Debug, Display, Formatter},
     iter::Peekable,
     num::ParseIntError,
@@ -8,7 +9,9 @@ pub(crate) use std::{
 
 /// Dependencies
 pub(crate) use serde::{
-    de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor},
+    de::{
+        DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess, Visitor,
+    },
     ser::{
         Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
         SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -203,11 +203,12 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         let bytes = self.next_bytes()?;
-        let value = f32::from_be_bytes(
+        let bits = u32::from_be_bytes(
             bytes
                 .try_into()
                 .map_err(|_| Error::InvalidF32(bytes.len()))?,
         );
+        let value = f32::from_bits(bits);
         visitor.visit_f32(value)
     }
 
@@ -216,11 +217,12 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         let bytes = self.next_bytes()?;
-        let value = f64::from_be_bytes(
+        let bits = u64::from_be_bytes(
             bytes
                 .try_into()
                 .map_err(|_| Error::InvalidF64(bytes.len()))?,
         );
+        let value = f64::from_bits(bits);
         visitor.visit_f64(value)
     }
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -203,7 +203,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         let bytes = self.next_bytes()?;
-        let value = f32::from_le_bytes(
+        let value = f32::from_be_bytes(
             bytes
                 .try_into()
                 .map_err(|_| Error::InvalidF32(bytes.len()))?,
@@ -216,7 +216,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         let bytes = self.next_bytes()?;
-        let value = f64::from_le_bytes(
+        let value = f64::from_be_bytes(
             bytes
                 .try_into()
                 .map_err(|_| Error::InvalidF64(bytes.len()))?,

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -81,6 +81,12 @@ impl<'de> Deserializer<'de> {
         }
     }
 
+    fn expect_empty_list(&mut self) -> Result<()> {
+        self.expect_list_begin()?;
+        self.expect_end()?;
+        Ok(())
+    }
+
     fn peek_end(&mut self) -> bool {
         self.peek() == Some(Token::End)
     }
@@ -97,18 +103,29 @@ impl<'de> Deserializer<'de> {
 impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::UnsupportedSelfDescribing)
+        match self.peek() {
+            Some(Token::Dict) => self.deserialize_map(visitor),
+            Some(Token::String(_)) => self.deserialize_bytes(visitor),
+            Some(Token::List) => self.deserialize_seq(visitor),
+            Some(Token::Num(_)) => self.deserialize_i64(visitor),
+            Some(Token::End) => Err(Error::Decode(StructureError::invalid_state("End").into())),
+            None => Err(Error::Decode(StructureError::UnexpectedEof.into())),
+        }
     }
 
-    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("bool"))
+        match self.next_integer()? {
+            "0" => visitor.visit_bool(false),
+            "1" => visitor.visit_bool(true),
+            other => Err(Error::InvalidBool(other.to_owned())),
+        }
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
@@ -181,25 +198,42 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_u128(self.next_integer()?.parse()?)
     }
 
-    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("f32"))
+        let bytes = self.next_bytes()?;
+        let value = f32::from_le_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| Error::InvalidF32(bytes.len()))?,
+        );
+        visitor.visit_f32(value)
     }
 
-    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("f64"))
+        let bytes = self.next_bytes()?;
+        let value = f64::from_le_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| Error::InvalidF64(bytes.len()))?,
+        );
+        visitor.visit_f64(value)
     }
 
-    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("char"))
+        let s: &str = self.next_string()?;
+        let count = s.chars().count();
+        if count != 1 {
+            return Err(Error::InvalidChar(count));
+        }
+        visitor.visit_char(s.chars().next().unwrap())
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -230,25 +264,33 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.deserialize_bytes(visitor)
     }
 
-    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("Option"))
+        self.expect_list_begin()?;
+        let value = if self.peek_end() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(&mut *self)
+        };
+        self.expect_end()?;
+        value
     }
 
-    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("()"))
+        self.expect_empty_list()?;
+        visitor.visit_unit()
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("unit struct"))
+        self.deserialize_unit(visitor)
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -287,11 +329,14 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.deserialize_seq(visitor)
     }
 
-    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("map"))
+        self.expect_dict_begin()?;
+        let value = visitor.visit_map(&mut *self)?;
+        self.expect_end()?;
+        Ok(value)
     }
 
     fn deserialize_struct<V>(
@@ -313,12 +358,17 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::unsupported_type("enum"))
+        if self.peek() == Some(Token::Dict) {
+            self.expect_dict_begin()?;
+            visitor.visit_enum(self)
+        } else {
+            visitor.visit_enum(self.next_string()?.into_deserializer())
+        }
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
@@ -328,11 +378,11 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::UnsupportedSelfDescribing)
+        self.deserialize_any(visitor)
     }
 }
 
@@ -375,11 +425,11 @@ impl<'de> EnumAccess<'de> for &mut Deserializer<'de> {
     type Error = Error;
     type Variant = Self;
 
-    fn variant_seed<V>(self, _seed: V) -> Result<(V::Value, Self)>
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self)>
     where
         V: DeserializeSeed<'de>,
     {
-        unreachable!()
+        Ok((seed.deserialize(&mut *self)?, self))
     }
 }
 
@@ -387,27 +437,33 @@ impl<'de> VariantAccess<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
-        unreachable!()
+        Ok(())
     }
 
-    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value>
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
         T: DeserializeSeed<'de>,
     {
-        unreachable!()
+        let value = seed.deserialize(&mut *self)?;
+        self.expect_end()?;
+        Ok(value)
     }
 
-    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        let value = serde::de::Deserializer::deserialize_seq(&mut *self, visitor)?;
+        self.expect_end()?;
+        Ok(value)
     }
 
-    fn struct_variant<V>(self, _fields: &'static [&'static str], _visitor: V) -> Result<V::Value>
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        let value = serde::de::Deserializer::deserialize_map(&mut *self, visitor)?;
+        self.expect_end()?;
+        Ok(value)
     }
 }

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -7,25 +7,31 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// deserialization
 #[derive(Debug)]
 pub enum Error {
+    /// Error that occurs if a map with a key type which does not serialize to
+    /// a byte string is encountered
+    ArbitraryMapKeysUnsupported,
+    /// Error that occurs if methods on MapSerializer are called out of order
+    MapSerializationCallOrder,
+    /// Error that occurs if a bool is deserialized from an integer value other
+    /// than `0` or `1`
+    InvalidBool(String),
+    /// Error that occurs if an f32 is deserialized from an string of length other
+    /// than 4
+    InvalidF32(usize),
+    /// Error that occurs if an f64 is deserialized from an string of length other
+    /// than 8
+    InvalidF64(usize),
+    /// Error that occurs if a char is deserialized from a string containing more
+    /// than one character
+    InvalidChar(usize),
     /// Error that occurs if a serde-related error occurs during serialization
     CustomEncode(String),
     /// Error that occurs if a serde-related error occurs during deserialization
     CustomDecode(String),
-    /// Error that occurs if the serializer or deserializer encounters an unsupported type
-    UnsupportedType(&'static str),
-    /// Error that occurs if the deserializer is used in a way that requires a self-describing
-    /// format, which is not yet supported
-    UnsupportedSelfDescribing,
     /// Error that occurs if a problem is encountered during serialization
     Encode(encoding::Error),
     /// Error that occurs if a problem is encountered during deserialization
     Decode(decoding::Error),
-}
-
-impl Error {
-    pub(crate) fn unsupported_type(name: &'static str) -> Error {
-        Self::UnsupportedType(name)
-    }
 }
 
 impl From<encoding::Error> for Error {
@@ -74,15 +80,23 @@ impl Display for Error {
             Self::CustomDecode(message) => write!(f, "Deserialization failed: {}", message),
             Self::Encode(error) => write!(f, "{}", error),
             Self::Decode(error) => write!(f, "{}", error),
-            Self::UnsupportedType(name) => write!(
+            Self::InvalidBool(value) => write!(f, "Invalid integer value for bool: `{}`", value),
+            Self::InvalidF32(length) => {
+                write!(f, "Invalid length byte string value for f32: {}", length)
+            },
+            Self::InvalidF64(length) => {
+                write!(f, "Invalid length byte string value for f64: {}", length)
+            },
+            Self::InvalidChar(length) => {
+                write!(f, "Invalid length string value for char: {}", length)
+            },
+            Self::ArbitraryMapKeysUnsupported => write!(
                 f,
-                "Serializing and deserializing values of type `{}` is not supported",
-                name
+                "Maps with key types that do not serialize to byte strings are unsupported",
             ),
-            Self::UnsupportedSelfDescribing => write!(
-                f,
-                "Deserialization that requires a self-describing format is not yet supported"
-            ),
+            Self::MapSerializationCallOrder => {
+                write!(f, "Map serialization methods called out of order")
+            },
         }
     }
 }

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -36,25 +36,25 @@ pub enum Error {
 
 impl From<encoding::Error> for Error {
     fn from(encoding_error: encoding::Error) -> Self {
-        Self::Encode(encoding_error)
+        Error::Encode(encoding_error)
     }
 }
 
 impl From<decoding::Error> for Error {
     fn from(decoding_error: decoding::Error) -> Self {
-        Self::Decode(decoding_error)
+        Error::Decode(decoding_error)
     }
 }
 
 impl From<ParseIntError> for Error {
     fn from(parse_int_error: ParseIntError) -> Self {
-        Self::Decode(parse_int_error.into())
+        Error::Decode(parse_int_error.into())
     }
 }
 
 impl From<Utf8Error> for Error {
     fn from(utf8_error: Utf8Error) -> Self {
-        Self::Decode(utf8_error.into())
+        Error::Decode(utf8_error.into())
     }
 }
 
@@ -63,38 +63,38 @@ impl serde::ser::Error for Error {
     where
         T: Display,
     {
-        Self::CustomEncode(msg.to_string())
+        Error::CustomEncode(msg.to_string())
     }
 }
 
 impl serde::de::Error for Error {
     fn custom<T: Display>(msg: T) -> Self {
-        Self::CustomDecode(msg.to_string())
+        Error::CustomDecode(msg.to_string())
     }
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::CustomEncode(message) => write!(f, "Serialization failed: {}", message),
-            Self::CustomDecode(message) => write!(f, "Deserialization failed: {}", message),
-            Self::Encode(error) => write!(f, "{}", error),
-            Self::Decode(error) => write!(f, "{}", error),
-            Self::InvalidBool(value) => write!(f, "Invalid integer value for bool: `{}`", value),
-            Self::InvalidF32(length) => {
+            Error::CustomEncode(message) => write!(f, "Serialization failed: {}", message),
+            Error::CustomDecode(message) => write!(f, "Deserialization failed: {}", message),
+            Error::Encode(error) => write!(f, "{}", error),
+            Error::Decode(error) => write!(f, "{}", error),
+            Error::InvalidBool(value) => write!(f, "Invalid integer value for bool: `{}`", value),
+            Error::InvalidF32(length) => {
                 write!(f, "Invalid length byte string value for f32: {}", length)
             },
-            Self::InvalidF64(length) => {
+            Error::InvalidF64(length) => {
                 write!(f, "Invalid length byte string value for f64: {}", length)
             },
-            Self::InvalidChar(length) => {
+            Error::InvalidChar(length) => {
                 write!(f, "Invalid length string value for char: {}", length)
             },
-            Self::ArbitraryMapKeysUnsupported => write!(
+            Error::ArbitraryMapKeysUnsupported => write!(
                 f,
                 "Maps with key types that do not serialize to byte strings are unsupported",
             ),
-            Self::MapSerializationCallOrder => {
+            Error::MapSerializationCallOrder => {
                 write!(f, "Map serialization methods called out of order")
             },
         }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -126,12 +126,12 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        let bytes = v.to_le_bytes();
+        let bytes = v.to_be_bytes();
         self.serialize_bytes(&bytes)
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        let bytes = v.to_le_bytes();
+        let bytes = v.to_be_bytes();
         self.serialize_bytes(&bytes)
     }
 

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -2,9 +2,11 @@
 
 use crate::serde::common::*;
 
-mod struct_serializer;
-
+pub use map_serializer::MapSerializer;
 pub use struct_serializer::StructSerializer;
+
+mod map_serializer;
+mod struct_serializer;
 
 /// Serialize an instance of `T` to bencode
 pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
@@ -40,21 +42,37 @@ impl Serializer {
     pub fn into_bytes(self) -> Result<Vec<u8>> {
         Ok(self.encoder.get_output()?)
     }
+
+    fn emit_empty_list(&mut self) -> Result<()> {
+        self.encoder.emit_list(|_| Ok(()))?;
+        Ok(())
+    }
+
+    fn begin_struct(&mut self) -> Result<StructSerializer> {
+        let encoder = self.encoder.begin_unsorted_dict()?;
+        Ok(StructSerializer::new(&mut self.encoder, encoder))
+    }
+
+    fn begin_map(&mut self) -> Result<MapSerializer> {
+        let encoder = self.encoder.begin_unsorted_dict()?;
+        Ok(MapSerializer::new(&mut self.encoder, encoder))
+    }
 }
 
 impl<'a> serde::ser::Serializer for &'a mut Serializer {
     type Error = Error;
     type Ok = ();
-    type SerializeMap = Self;
+    type SerializeMap = MapSerializer<'a>;
     type SerializeSeq = Self;
     type SerializeStruct = StructSerializer<'a>;
-    type SerializeStructVariant = Self;
+    type SerializeStructVariant = StructSerializer<'a>;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
 
-    fn serialize_bool(self, _v: bool) -> Result<()> {
-        Err(Error::unsupported_type("bool"))
+    fn serialize_bool(self, v: bool) -> Result<()> {
+        self.encoder.emit(if v { 1 } else { 0 })?;
+        Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
@@ -107,16 +125,19 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
         Ok(())
     }
 
-    fn serialize_f32(self, _v: f32) -> Result<()> {
-        Err(Error::unsupported_type("f32"))
+    fn serialize_f32(self, v: f32) -> Result<()> {
+        let bytes = v.to_le_bytes();
+        self.serialize_bytes(&bytes)
     }
 
-    fn serialize_f64(self, _v: f64) -> Result<()> {
-        Err(Error::unsupported_type("f64"))
+    fn serialize_f64(self, v: f64) -> Result<()> {
+        let bytes = v.to_le_bytes();
+        self.serialize_bytes(&bytes)
     }
 
-    fn serialize_char(self, _v: char) -> Result<()> {
-        Err(Error::unsupported_type("char"))
+    fn serialize_char(self, v: char) -> Result<()> {
+        let mut buffer: [u8; 4] = [0; 4];
+        self.serialize_str(v.encode_utf8(&mut buffer))
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
@@ -129,31 +150,25 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_none(self) -> Result<()> {
-        Err(Error::unsupported_type("Option"))
+        self.emit_empty_list()
     }
 
-    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        Err(Error::unsupported_type("Option"))
+        self.encoder.emit_token(Token::List)?;
+        value.serialize(&mut *self)?;
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
     }
 
     fn serialize_unit(self) -> Result<()> {
-        Err(Error::unsupported_type("()"))
+        self.emit_empty_list()
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
-        Err(Error::unsupported_type("unit struct"))
-    }
-
-    fn serialize_unit_variant(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-    ) -> Result<()> {
-        Err(Error::unsupported_type("enum unit variant"))
+        self.emit_empty_list()
     }
 
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
@@ -161,19 +176,6 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
         T: ?Sized + Serialize,
     {
         value.serialize(self)
-    }
-
-    fn serialize_newtype_variant<T>(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _value: &T,
-    ) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Error::unsupported_type("enum newtype variant"))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
@@ -195,33 +197,63 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
         Ok(self)
     }
 
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        self.begin_map()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<()> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.encoder.emit_token(Token::Dict)?;
+        self.serialize_str(variant)?;
+        value.serialize(&mut *self)?;
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        self.begin_struct()
+    }
+
     fn serialize_tuple_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Err(Error::unsupported_type("enum tuple variant"))
-    }
-
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        Err(Error::unsupported_type("map"))
-    }
-
-    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        let encoder = self.encoder.begin_unsorted_dict()?;
-        Ok(StructSerializer::new(&mut self.encoder, encoder))
+        self.encoder.emit_token(Token::Dict)?;
+        self.serialize_str(variant)?;
+        self.encoder.emit_token(Token::List)?;
+        Ok(self)
     }
 
     fn serialize_struct_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Err(Error::unsupported_type("enum struct variant"))
+        self.encoder.emit_token(Token::Dict)?;
+        self.serialize_str(variant)?;
+        self.begin_struct()
     }
 }
 
@@ -303,15 +335,17 @@ impl<'a> SerializeTupleVariant for &'a mut Serializer {
     type Error = Error;
     type Ok = ();
 
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unreachable!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unreachable!()
+        self.encoder.emit_token(Token::End)?;
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
     }
 }
 
@@ -327,6 +361,8 @@ impl<'a> SerializeStructVariant for &'a mut Serializer {
     }
 
     fn end(self) -> Result<()> {
-        unreachable!()
+        self.encoder.emit_token(Token::End)?;
+        self.encoder.emit_token(Token::End)?;
+        Ok(())
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -126,12 +126,12 @@ impl<'a> serde::ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        let bytes = v.to_be_bytes();
+        let bytes = v.to_bits().to_be_bytes();
         self.serialize_bytes(&bytes)
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        let bytes = v.to_be_bytes();
+        let bytes = v.to_bits().to_be_bytes();
         self.serialize_bytes(&bytes)
     }
 

--- a/src/serde/ser/map_serializer.rs
+++ b/src/serde/ser/map_serializer.rs
@@ -1,0 +1,80 @@
+use crate::serde::common::*;
+
+/// Bencode sub-serializer for maps.
+pub struct MapSerializer<'outer> {
+    pub(crate) outer: &'outer mut Encoder,
+    encoder: UnsortedDictEncoder,
+    key: Option<Vec<u8>>,
+}
+
+impl<'outer> MapSerializer<'outer> {
+    pub(crate) fn new(
+        outer: &'outer mut Encoder,
+        encoder: UnsortedDictEncoder,
+    ) -> MapSerializer<'outer> {
+        MapSerializer {
+            encoder,
+            outer,
+            key: None,
+        }
+    }
+
+    fn serialize<T>(&self, value: &T) -> Result<Vec<u8>>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut serializer = Serializer::with_max_depth(self.encoder.remaining_depth());
+        value.serialize(&mut serializer)?;
+        serializer.into_bytes()
+    }
+}
+
+impl<'outer> SerializeMap for MapSerializer<'outer> {
+    type Error = Error;
+    type Ok = ();
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if self.key.is_some() {
+            return Err(Error::MapSerializationCallOrder);
+        }
+
+        let mut encoded = self.serialize(key)?;
+
+        match encoded.first() {
+            Some(b'0'..=b'9') => {},
+            _ => return Err(Error::ArbitraryMapKeysUnsupported),
+        }
+
+        let colon = encoded.iter().position(|b| *b == b':').unwrap();
+        encoded.drain(0..colon + 1);
+
+        self.key = Some(encoded);
+
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self.key.take() {
+            Some(bytes) => {
+                let encoded = self.serialize(value)?;
+                self.encoder.save_pair(&bytes, encoded)?;
+                Ok(())
+            },
+            None => Err(Error::MapSerializationCallOrder),
+        }
+    }
+
+    fn end(self) -> Result<()> {
+        if self.key.is_some() {
+            return Err(Error::MapSerializationCallOrder);
+        }
+        self.outer.end_unsorted_dict(self.encoder)?;
+        Ok(())
+    }
+}

--- a/src/serde/ser/struct_serializer.rs
+++ b/src/serde/ser/struct_serializer.rs
@@ -13,13 +13,8 @@ impl<'outer> StructSerializer<'outer> {
     ) -> StructSerializer<'outer> {
         StructSerializer { encoder, outer }
     }
-}
 
-impl<'outer> SerializeStruct for StructSerializer<'outer> {
-    type Error = Error;
-    type Ok = ();
-
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn save_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
@@ -31,9 +26,39 @@ impl<'outer> SerializeStruct for StructSerializer<'outer> {
 
         Ok(())
     }
+}
+
+impl<'outer> SerializeStruct for StructSerializer<'outer> {
+    type Error = Error;
+    type Ok = ();
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.save_field(key, value)
+    }
 
     fn end(self) -> Result<()> {
         self.outer.end_unsorted_dict(self.encoder)?;
+        Ok(())
+    }
+}
+
+impl<'outer> SerializeStructVariant for StructSerializer<'outer> {
+    type Error = Error;
+    type Ok = ();
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.save_field(key, value)
+    }
+
+    fn end(self) -> Result<()> {
+        self.outer.end_unsorted_dict(self.encoder)?;
+        self.outer.emit_token(Token::End)?;
         Ok(())
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,13 +10,16 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use std::{
     convert::TryInto,
     fmt::{self, Formatter},
 };
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
+use serde_ as serde;
+
+#[cfg(feature = "serde")]
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Serialize,
@@ -95,7 +98,7 @@ impl<'a> FromBencode for Value<'a> {
     }
 }
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 mod serde_impls {
     use super::*;
 
@@ -235,7 +238,7 @@ mod tests {
 
         assert_eq!(decoded, value);
 
-        #[cfg(feature = "serde_support")]
+        #[cfg(feature = "serde")]
         {
             let deserialized = match crate::serde::de::from_bytes::<Value>(expected) {
                 Ok(deserialized) => deserialized,

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,13 +10,13 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_support")]
 use std::{
     convert::TryInto,
     fmt::{self, Formatter},
 };
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_support")]
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Serialize,
@@ -95,7 +95,7 @@ impl<'a> FromBencode for Value<'a> {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_support")]
 mod serde_impls {
     use super::*;
 
@@ -235,7 +235,7 @@ mod tests {
 
         assert_eq!(decoded, value);
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "serde_support")]
         {
             let deserialized = match crate::serde::de::from_bytes::<Value>(expected) {
                 Ok(deserialized) => deserialized,

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,298 @@
+//! `Value`s hold arbitrary borrowed or owneed bencode data. Unlike `Objects`,
+//! they can be cloned and traversed multiple times.
+//!
+//! `Value` implements `FromBencode`, `ToBencode`. If the `serde` feature is
+//! enabled, it also implements `Serialize` and `Deserialize`.
+
+use std::{borrow::Cow, collections::BTreeMap};
+
+#[cfg(feature = "serde")]
+use std::{
+    convert::TryInto,
+    fmt::{self, Formatter},
+};
+
+#[cfg(feature = "serde")]
+use serde_bytes::Bytes;
+
+#[cfg(feature = "serde")]
+use serde::{
+    ser::{SerializeMap, SerializeSeq},
+    Serialize,
+};
+
+use crate::{
+    decoding::{FromBencode, Object},
+    encoding::{SingleItemEncoder, ToBencode},
+};
+
+/// An owned or borrowed bencoded value.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum Value<'a> {
+    /// An owned or borrowed byte string
+    Bytes(Cow<'a, [u8]>),
+    /// A dictionary mapping byte strings to values
+    Dict(BTreeMap<Cow<'a, [u8]>, Value<'a>>),
+    /// A signed integer
+    Integer(i64),
+    /// A list of values
+    List(Vec<Value<'a>>),
+}
+
+impl<'a> Value<'a> {
+    /// Convert this Value into an owned Value with static lifetime
+    pub fn into_owned(self) -> Value<'static> {
+        match self {
+            Value::Bytes(bytes) => Value::Bytes(Cow::Owned(bytes.into_owned())),
+            Value::Dict(dict) => Value::Dict(
+                dict.into_iter()
+                    .map(|(key, value)| (Cow::Owned(key.into_owned()), value.into_owned()))
+                    .collect(),
+            ),
+            Value::Integer(integer) => Value::Integer(integer),
+            Value::List(list) => Value::List(list.into_iter().map(Value::into_owned).collect()),
+        }
+    }
+}
+
+impl<'a> ToBencode for Value<'a> {
+    const MAX_DEPTH: usize = usize::max_value();
+
+    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), crate::encoding::Error> {
+        match self {
+            Self::Bytes(bytes) => encoder.emit_bytes(bytes),
+            Self::Dict(dict) => dict.encode(encoder),
+            Self::Integer(integer) => integer.encode(encoder),
+            Self::List(list) => list.encode(encoder),
+        }
+    }
+}
+
+impl<'a> FromBencode for Value<'a> {
+    fn decode_bencode_object(object: Object) -> Result<Self, crate::decoding::Error> {
+        match object {
+            Object::Bytes(bytes) => Ok(Value::Bytes(Cow::Owned(bytes.to_owned()))),
+            Object::Dict(mut decoder) => {
+                let mut dict = BTreeMap::new();
+                while let Some((key, value)) = decoder.next_pair()? {
+                    dict.insert(
+                        Cow::Owned(key.to_owned()),
+                        Value::decode_bencode_object(value)?,
+                    );
+                }
+                Ok(Value::Dict(dict))
+            },
+            Object::Integer(text) => Ok(Value::Integer(text.parse()?)),
+            Object::List(mut decoder) => {
+                let mut list = Vec::new();
+                while let Some(object) = decoder.next_object()? {
+                    list.push(Value::decode_bencode_object(object)?);
+                }
+                Ok(Value::List(list))
+            },
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a> Serialize for Value<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        match self {
+            Value::Bytes(string) => serializer.serialize_bytes(string),
+            Value::Integer(int) => serializer.serialize_i64(*int),
+            Value::List(list) => {
+                let mut seed = serializer.serialize_seq(Some(list.len()))?;
+                for value in list {
+                    seed.serialize_element(value)?;
+                }
+                seed.end()
+            },
+            Value::Dict(dict) => {
+                let mut seed = serializer.serialize_map(Some(dict.len()))?;
+                for (k, v) in dict {
+                    let bytes = Bytes::new(k);
+                    seed.serialize_entry(bytes, v)?;
+                }
+                seed.end()
+            },
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a> serde::de::Deserialize<'a> for Value<'a> {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Value<'a>, D::Error>
+    where
+        D: serde::de::Deserializer<'a>,
+    {
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+struct Visitor;
+
+#[cfg(feature = "serde")]
+impl<'a> serde::de::Visitor<'a> for Visitor {
+    type Value = Value<'a>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str("any valid BEncode value")
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Value<'a>, E> {
+        Ok(Value::Integer(value))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Value<'a>, E> {
+        Ok(Value::Integer(value.try_into().unwrap()))
+    }
+
+    fn visit_borrowed_bytes<E>(self, value: &'a [u8]) -> Result<Value<'a>, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Value::Bytes(Cow::Borrowed(value)))
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'a str) -> Result<Value<'a>, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Value::Bytes(Cow::Borrowed(value.as_bytes())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Value<'a>, E> {
+        Ok(Value::Bytes(Cow::Owned(value.into_bytes())))
+    }
+
+    fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Value<'a>, E> {
+        Ok(Value::Bytes(Cow::Owned(value)))
+    }
+
+    fn visit_seq<V>(self, mut access: V) -> Result<Value<'a>, V::Error>
+    where
+        V: serde::de::SeqAccess<'a>,
+    {
+        let mut list = Vec::new();
+        while let Some(e) = access.next_element()? {
+            list.push(e);
+        }
+        Ok(Value::List(list))
+    }
+
+    fn visit_map<V>(self, mut access: V) -> Result<Value<'a>, V::Error>
+    where
+        V: serde::de::MapAccess<'a>,
+    {
+        let mut map = BTreeMap::new();
+        while let Some((k, v)) = access.next_entry::<&Bytes, _>()? {
+            map.insert(Cow::Borrowed(k.as_ref()), v);
+        }
+        Ok(Value::Dict(map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn case(value: Value, expected: impl AsRef<[u8]>) {
+        let expected = expected.as_ref();
+
+        let encoded = match value.to_bencode() {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("Failed to encode `{:?}`: {}", value, err),
+        };
+
+        if encoded != expected {
+            panic!(
+                "Expected `{:?}` to encode as `{}`, but got `{}",
+                value,
+                String::from_utf8_lossy(expected),
+                String::from_utf8_lossy(&encoded)
+            )
+        }
+
+        let decoded = match Value::from_bencode(&encoded) {
+            Ok(decoded) => decoded,
+            Err(err) => panic!(
+                "Failed to decode value from `{}`: {}",
+                String::from_utf8_lossy(&encoded),
+                err,
+            ),
+        };
+
+        assert_eq!(decoded, value);
+
+        #[cfg(feature = "serde")]
+        {
+            let deserialized = match crate::serde::de::from_bytes::<Value>(expected) {
+                Ok(deserialized) => deserialized,
+                Err(err) => panic!(
+                    "Failed to deserialize value from `{}`: {}",
+                    String::from_utf8_lossy(&expected),
+                    err
+                ),
+            };
+
+            if deserialized != value {
+                panic!(
+                    "Deserialize Serialize produced unexpected value: `{:?}` != `{:?}`",
+                    deserialized, value
+                );
+            }
+
+            let serialized = match crate::serde::ser::to_bytes(&value) {
+                Ok(serialized) => serialized,
+                Err(err) => panic!("Failed to serialize `{:?}`: {}", value, err),
+            };
+
+            if serialized != expected {
+                panic!(
+                    "Serialize Serialize produced unexpected bencode: `{:?}` != `{:?}`",
+                    String::from_utf8_lossy(&serialized),
+                    String::from_utf8_lossy(expected)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bytes() {
+        case(Value::Bytes(Cow::Borrowed(&[1, 2, 3])), b"3:\x01\x02\x03");
+        case(Value::Bytes(Cow::Owned(vec![1, 2, 3])), b"3:\x01\x02\x03");
+    }
+
+    #[test]
+    fn dict() {
+        case(Value::Dict(BTreeMap::new()), "de");
+
+        let mut dict = BTreeMap::new();
+        dict.insert(Cow::Borrowed("foo".as_bytes()), Value::Integer(1));
+        dict.insert(Cow::Borrowed("bar".as_bytes()), Value::Integer(2));
+        case(Value::Dict(dict), "d3:bari2e3:fooi1ee");
+    }
+
+    #[test]
+    fn integer() {
+        case(Value::Integer(0), "i0e");
+        case(Value::Integer(-1), "i-1e");
+    }
+
+    #[test]
+    fn list() {
+        case(Value::List(Vec::new()), "le");
+        case(
+            Value::List(vec![
+                Value::Integer(0),
+                Value::Bytes(Cow::Borrowed(&[1, 2, 3])),
+            ]),
+            b"li0e3:\x01\x02\x03e",
+        );
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,16 +10,13 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use std::{
     convert::TryInto,
     fmt::{self, Formatter},
 };
 
-#[cfg(feature = "serde_support")]
-use serde_bytes::Bytes;
-
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Serialize,
@@ -98,9 +95,11 @@ impl<'a> FromBencode for Value<'a> {
     }
 }
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 mod serde_impls {
     use super::*;
+
+    use serde_bytes::Bytes;
 
     impl<'a> Serialize for Value<'a> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Value implements both FromBencode and ToBencode, for conversion to and
from owned values.

With the serde feature enabled, Value implements Serialize and
Deserialize. Deserialize can be used to deserialize Values that borrow
from an input buffer.

I'm not sure if this is something that's appropriate for Bendy, but I needed it
for my own use, so I thought I would open a PR. If you'd prefer not to add it,
I can easily use it from my own crate instead.

I wrote a program that traverses large collections of `.torrent` files to extract
statistics and other information, and for a few reasons I'm unable to use bendy's
`Object` type. In particular, I need the ability to traverse a value multiple times,
but `Object` requires decoding as you go, so values can't be reused.

Also, for ergonomic reasons, I need to be able to clone values from the middle
of a bencoded object, which doesn't seem to be possible with `Object.

It might be somewhat confusing when someone might want an `Object` and when
they might want a `Value`, so I added documentation to the `Value` module
explaining the difference.