### PR TITLE
Add deserializer option to forbid trailing bytes

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -142,7 +142,10 @@ mod tests {
 
     use std::{collections::HashMap, fmt::Debug};
 
-    use super::{de::from_bytes, ser::to_bytes};
+    use super::{
+        de::{from_bytes, Deserializer},
+        ser::to_bytes,
+    };
 
     use serde::{de::DeserializeOwned, ser::Serialize};
     use serde_derive::{Deserialize, Serialize};
@@ -479,5 +482,23 @@ mod tests {
     #[test]
     fn invalid_char() {
         assert_matches!(from_bytes::<char>(b"2:00"), Err(Error::InvalidChar(2)));
+    }
+
+    #[test]
+    fn trailing_bytes_forbid() {
+        assert_matches!(
+            Deserializer::from_bytes(b"i1ei1e")
+                .with_forbid_trailing_bytes(true)
+                .deserialize::<u32>(),
+            Err(Error::TrailingBytes)
+        );
+    }
+
+    #[test]
+    fn trailing_bytes_allow() {
+        assert_matches!(
+            Deserializer::from_bytes(b"i1ei1e").deserialize::<u32>(),
+            Ok(1)
+        );
     }
 }

--- a/src/serde/error.rs
+++ b/src/serde/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     /// Error that occurs if a char is deserialized from a string containing more
     /// than one character
     InvalidChar(usize),
+    /// Error that occurs if trailing bytes remain after deserialization, if the
+    /// deserializer is configured to forbid trailing bytes
+    TrailingBytes,
     /// Error that occurs if a serde-related error occurs during serialization
     CustomEncode(String),
     /// Error that occurs if a serde-related error occurs during deserialization
@@ -90,6 +93,7 @@ impl Display for Error {
             Error::InvalidChar(length) => {
                 write!(f, "Invalid length string value for char: {}", length)
             },
+            Error::TrailingBytes => write!(f, "Trailing bytes remain after deserializing value"),
             Error::ArbitraryMapKeysUnsupported => write!(
                 f,
                 "Maps with key types that do not serialize to byte strings are unsupported",


### PR DESCRIPTION
Optionally, the deserializer can be configured to throw an error if
trailing bytes remain after deserialization.

I'm writing a tool to verify a huge archive of torrents, and I want
to be able to be strict about trailing data not following a valid
bencoded dict.