### PR TITLE
Add justfile with `test` recipe

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ indent_style = space
 indent_size = 4
 # Trim trailing whitespace
 trim_trailing_whitespace = true
+
+# use tabs for justfile
+[justfile]
+indent_style = tab

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+# just is a cross-platform command runner:
+# https://github.com/casey/just
+
+default: test
+
+# install the minimum version of rust supported by bendy
+install-minimum-supported-rust:
+	rustup install 1.36.0
+
+# test all combinations of features, as well as the minimum supported version of rust
+test:
+	rm -f Cargo.lock
+	cargo test --all
+	cargo test --all --no-default-features
+	cargo test --all --features serde
+	rm -f Cargo.lock
+	cargo +1.36.0 test --all
+	cargo +1.36.0 test --all --no-default-features
+	cargo +1.36.0 test --all --features serde


### PR DESCRIPTION
I found this recipe useful while testing, to run the tests as the run on continuous integration. It tests all packages with all combinations of supported features, both on stable rust and 1.36. You can run it with `just test`.

[Just](https://github.com/casey/just) is a make-like command runner, which I think is great, but I am hopelessly biased on the matter, because I wrote it. Compared to make has the benefit of being cross-platform, giving much better error messages, and not having a build system at all, but it has the pretty substantial downside of not being installed everywhere. (Although you can get it via crates.io with `cargo install just`.)

If you think it would be better to use Make, I can definitely change it into a Makefile.