### PR TITLE
decouple deserializer lifetime from value

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -501,4 +501,22 @@ mod tests {
             Ok(1)
         );
     }
+
+    #[test]
+    fn borrowed_value() {
+        use std::borrow::Cow;
+        use crate::value::Value;
+
+        #[derive(Debug, Deserialize, PartialEq, Eq)]
+        #[serde(crate = "serde_")]
+        struct Dict<'a> {
+            #[serde(borrow)]
+            v: Value<'a>,
+        }
+
+        assert_eq!(
+            Deserializer::from_bytes(b"d1:v3:\x01\x02\x03e").deserialize::<Dict<'_>>().unwrap(),
+            Dict { v: Value::Bytes(Cow::Owned(vec![1, 2, 3]))},
+        );
+    }
 }


### PR DESCRIPTION
This allows deriving `Deserialize` for types that contain `Value` with `serde(borrow)`, as shown in the added test.

[See the serde docs for more information](https://serde.rs/lifetimes.html#the-deserializede-lifetime).