### PR TITLE
[Draft] Parameterize decode and encode related structs and traits with `StateTracker`

### DIFF
--- a/examples/decode_torrent.rs
+++ b/examples/decode_torrent.rs
@@ -15,7 +15,7 @@
 //! ```
 
 use bendy::{
-    decoding::{Error, FromBencode, Object, ResultExt},
+    decoding::{Error, FromBencode, ResultExt, StrictObject},
     encoding::AsString,
 };
 
@@ -80,7 +80,7 @@ impl FromBencode for MetaInfo {
     /// non-optional and optional fields. Missing optional fields are ignored
     /// but any other missing fields result in stopping the decoding and in
     /// spawning [`DecodingError::MissingField`].
-    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    fn decode_bencode_object(object: StrictObject) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -146,7 +146,7 @@ impl FromBencode for Info {
     /// On success the dictionary is parsed for the fields of info which are
     /// necessary for torrent. Any missing field will result in a missing field
     /// error which will stop the decoding.
-    fn decode_bencode_object(object: Object) -> Result<Self, Error>
+    fn decode_bencode_object(object: StrictObject) -> Result<Self, Error>
     where
         Self: Sized,
     {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-required_version = "1.4.11"
+required_version = "1.4.21"
 edition = "2018"
 
 format_code_in_doc_comments = true

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -4,7 +4,7 @@
 //! For any decoding process, first we need to create a decoder:
 //!
 //! ```
-//! # use bendy::decoding::{Decoder};
+//! # use bendy::decoding::StrictDecoder as Decoder;
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
 //! let _decoder = Decoder::new(buf);
@@ -16,7 +16,7 @@
 //! attacker can cause your program to use, so we recommend setting the bounds tightly:
 //!
 //! ```
-//! # use bendy::decoding::{Decoder};
+//! # use bendy::decoding::StrictDecoder as Decoder;
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
 //! let _decoder = Decoder::new(buf).with_max_depth(3);
@@ -28,10 +28,10 @@
 //! Now, you can start reading objects:
 //!
 //! ```
-//! # use bendy::decoding::{Decoder,Object};
+//! # use bendy::decoding::{StrictDecoder as Decoder, StrictObject as Object};
 //! #
-//! # fn decode_list(_: bendy::decoding::ListDecoder) {}
-//! # fn decode_dict(_: bendy::decoding::DictDecoder) {}
+//! # fn decode_list(_: bendy::decoding::StrictListDecoder) {}
+//! # fn decode_dict(_: bendy::decoding::StrictDictDecoder) {}
 //! #
 //! # let buf: &[u8] = b"d3:fooi1ee";
 //! # let mut decoder = Decoder::new(buf);
@@ -52,7 +52,7 @@
 //! of an input object without fully decoding it:
 //!
 //! ```
-//! # use bendy::decoding::Decoder;
+//! # use bendy::decoding::StrictDecoder as Decoder;
 //! #
 //! fn syntax_check(buf: &[u8]) -> bool {
 //!     let mut decoder = Decoder::new(buf);
@@ -69,8 +69,11 @@ mod from_bencode;
 mod object;
 
 pub use self::{
-    decoder::{Decoder, DictDecoder, ListDecoder, Tokens},
+    decoder::{
+        Decoder, DictDecoder, ListDecoder, StrictDecoder, StrictDictDecoder, StrictListDecoder,
+        Tokens,
+    },
     error::{Error, ErrorKind, ResultExt},
     from_bencode::FromBencode,
-    object::Object,
+    object::{Object, StrictObject},
 };

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -3,7 +3,7 @@ use core::str;
 
 use crate::{
     decoding::{Error, Object},
-    state_tracker::{StrictTracker, StructureError, Token},
+    state_tracker::{StateTracker, StrictTracker, StructureError, Token},
 };
 
 /// A bencode decoder

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -3,7 +3,7 @@ use core::str;
 
 use crate::{
     decoding::{Error, Object},
-    state_tracker::{StateTracker, StructureError, Token},
+    state_tracker::{StrictTracker, StructureError, Token},
 };
 
 /// A bencode decoder
@@ -14,7 +14,7 @@ use crate::{
 pub struct Decoder<'a> {
     source: &'a [u8],
     offset: usize,
-    state: StateTracker<&'a [u8], Error>,
+    state: StrictTracker<&'a [u8], Error>,
 }
 
 impl<'ser> Decoder<'ser> {
@@ -23,7 +23,7 @@ impl<'ser> Decoder<'ser> {
         Decoder {
             source: buffer,
             offset: 0,
-            state: StateTracker::new(),
+            state: StrictTracker::new(),
         }
     }
 

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -11,14 +11,14 @@ use std::{collections::BTreeMap, vec::Vec};
 
 use crate::{
     encoding::{Error, PrintableInteger, ToBencode},
-    state_tracker::{StateTracker, StructureError, Token},
+    state_tracker::{StrictTracker, StructureError, Token},
 };
 
 /// The actual encoder. Unlike the decoder, this is not zero-copy, as that would
 /// result in a horrible interface
 #[derive(Default, Debug)]
 pub struct Encoder {
-    state: StateTracker<Vec<u8>, Error>,
+    state: StrictTracker<Vec<u8>, Error>,
     output: Vec<u8>,
 }
 

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeMap, vec::Vec};
 
 use crate::{
     encoding::{Error, PrintableInteger, ToBencode},
-    state_tracker::{StrictTracker, StructureError, Token},
+    state_tracker::{StateTracker, StrictTracker, StructureError, Token},
 };
 
 /// The actual encoder. Unlike the decoder, this is not zero-copy, as that would

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,11 @@ pub mod state_tracker;
 pub mod serde;
 
 pub mod value;
+
+//------------------------------------------------------------------------------
+// Helper
+//------------------------------------------------------------------------------
+
+use self::{decoding::Error, state_tracker::StrictTracker};
+
+type StrictByteTracker<'ser> = StrictTracker<&'ser [u8], Error>;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -531,8 +531,8 @@ mod tests {
 
     #[test]
     fn borrowed_value() {
-        use std::borrow::Cow;
         use crate::value::Value;
+        use std::borrow::Cow;
 
         #[derive(Debug, Deserialize, PartialEq, Eq)]
         #[serde(crate = "serde_")]
@@ -542,8 +542,12 @@ mod tests {
         }
 
         assert_eq!(
-            Deserializer::from_bytes(b"d1:v3:\x01\x02\x03e").deserialize::<Dict<'_>>().unwrap(),
-            Dict { v: Value::Bytes(Cow::Owned(vec![1, 2, 3]))},
+            Deserializer::from_bytes(b"d1:v3:\x01\x02\x03e")
+                .deserialize::<Dict<'_>>()
+                .unwrap(),
+            Dict {
+                v: Value::Bytes(Cow::Owned(vec![1, 2, 3]))
+            },
         );
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -5,9 +5,9 @@
 //! deserialized from bencode with `bendy::serde::from_bytes`:
 //!
 //! ```
-//! use bendy::serde::{to_bytes, from_bytes};
+//! use bendy::serde::{from_bytes, to_bytes};
 //! use serde_ as serde;
-//! use serde_derive::{Serialize, Deserialize};
+//! use serde_derive::{Deserialize, Serialize};
 //!
 //! assert_eq!(to_bytes(&10).unwrap(), b"i10e");
 //! assert_eq!(from_bytes::<u64>(b"i10e").unwrap(), 10);

--- a/src/state_tracker.rs
+++ b/src/state_tracker.rs
@@ -3,9 +3,6 @@ mod state;
 mod structure_error;
 mod token;
 
-pub use self::token::Token;
-pub(crate) use self::{
-    stack::Stack,
-    state::{StateTracker, StrictTracker},
-    structure_error::StructureError,
-};
+pub use self::{state::StateTracker, token::Token};
+
+pub(crate) use self::{stack::Stack, state::StrictTracker, structure_error::StructureError};

--- a/src/state_tracker.rs
+++ b/src/state_tracker.rs
@@ -4,4 +4,4 @@ mod structure_error;
 mod token;
 
 pub use self::token::Token;
-pub(crate) use self::{stack::Stack, state::StateTracker, structure_error::StructureError};
+pub(crate) use self::{stack::Stack, state::StrictTracker, structure_error::StructureError};

--- a/src/state_tracker.rs
+++ b/src/state_tracker.rs
@@ -4,4 +4,8 @@ mod structure_error;
 mod token;
 
 pub use self::token::Token;
-pub(crate) use self::{stack::Stack, state::StrictTracker, structure_error::StructureError};
+pub(crate) use self::{
+    stack::Stack,
+    state::{StateTracker, StrictTracker},
+    structure_error::StructureError,
+};

--- a/src/state_tracker/state.rs
+++ b/src/state_tracker/state.rs
@@ -3,6 +3,34 @@ use alloc::vec::Vec;
 
 use crate::state_tracker::{Stack, StructureError, Token};
 
+//------------------------------------------------------------------------------
+// StateTracker
+//------------------------------------------------------------------------------
+
+/// Used to validate that a structure is valid
+pub(crate) trait StateTracker<S, E> {
+    fn new() -> Self;
+
+    fn set_max_depth(&mut self, new_max_depth: usize);
+
+    fn remaining_depth(&self) -> usize;
+
+    /// Observe that an EOF was seen. This function is idempotent.
+    fn observe_eof(&mut self) -> Result<(), E>;
+
+    fn observe_token<'a>(&mut self, token: &Token<'a>) -> Result<(), E>
+    where
+        S: From<&'a [u8]>;
+
+    fn latch_err<T>(&mut self, result: Result<T, E>) -> Result<T, E>;
+
+    fn check_error(&self) -> Result<(), E>;
+}
+
+//------------------------------------------------------------------------------
+// State
+//------------------------------------------------------------------------------
+
 /// The state of current level of the decoder
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 enum State<S: AsRef<[u8]>, E> {
@@ -15,6 +43,10 @@ enum State<S: AsRef<[u8]>, E> {
     /// Received an error while decoding
     Failed(E),
 }
+
+//------------------------------------------------------------------------------
+// StrictTracker
+//------------------------------------------------------------------------------
 
 /// Used to validate that a structure is valid
 #[derive(Debug)]
@@ -32,25 +64,25 @@ impl<S: AsRef<[u8]>, E> Default for StrictTracker<S, E> {
     }
 }
 
-impl<S: AsRef<[u8]>, E> StrictTracker<S, E>
+impl<S, E> StateTracker<S, E> for StrictTracker<S, E>
 where
     S: AsRef<[u8]>,
     E: From<StructureError> + Clone,
 {
-    pub fn new() -> Self {
+    fn new() -> Self {
         <Self as Default>::default()
     }
 
-    pub fn set_max_depth(&mut self, new_max_depth: usize) {
+    fn set_max_depth(&mut self, new_max_depth: usize) {
         self.max_depth = new_max_depth
     }
 
-    pub fn remaining_depth(&self) -> usize {
+    fn remaining_depth(&self) -> usize {
         self.max_depth - self.state.len()
     }
 
     /// Observe that an EOF was seen. This function is idempotent.
-    pub fn observe_eof(&mut self) -> Result<(), E> {
+    fn observe_eof(&mut self) -> Result<(), E> {
         self.check_error()?;
 
         if self.state.is_empty() {
@@ -61,7 +93,7 @@ where
     }
 
     #[allow(clippy::match_same_arms)]
-    pub fn observe_token<'a>(&mut self, token: &Token<'a>) -> Result<(), E>
+    fn observe_token<'a>(&mut self, token: &Token<'a>) -> Result<(), E>
     where
         S: From<&'a [u8]>,
     {
@@ -141,7 +173,7 @@ where
         Ok(())
     }
 
-    pub fn latch_err<T>(&mut self, result: Result<T, E>) -> Result<T, E> {
+    fn latch_err<T>(&mut self, result: Result<T, E>) -> Result<T, E> {
         self.check_error()?;
         if let Err(ref err) = result {
             self.state.push(State::Failed(err.clone()))
@@ -149,7 +181,7 @@ where
         result
     }
 
-    pub fn check_error(&self) -> Result<(), E> {
+    fn check_error(&self) -> Result<(), E> {
         if let Some(&State::Failed(ref error)) = self.state.peek() {
             Err(error.clone())
         } else {

--- a/src/state_tracker/state.rs
+++ b/src/state_tracker/state.rs
@@ -8,7 +8,7 @@ use crate::state_tracker::{Stack, StructureError, Token};
 //------------------------------------------------------------------------------
 
 /// Used to validate that a structure is valid
-pub(crate) trait StateTracker<S, E> {
+pub trait StateTracker<S, E = StructureError> {
     fn new() -> Self;
 
     fn set_max_depth(&mut self, new_max_depth: usize);

--- a/src/state_tracker/state.rs
+++ b/src/state_tracker/state.rs
@@ -18,21 +18,21 @@ enum State<S: AsRef<[u8]>, E> {
 
 /// Used to validate that a structure is valid
 #[derive(Debug)]
-pub struct StateTracker<S: AsRef<[u8]>, E = StructureError> {
+pub struct StrictTracker<S: AsRef<[u8]>, E = StructureError> {
     state: Vec<State<S, E>>,
     max_depth: usize,
 }
 
-impl<S: AsRef<[u8]>, E> Default for StateTracker<S, E> {
+impl<S: AsRef<[u8]>, E> Default for StrictTracker<S, E> {
     fn default() -> Self {
-        StateTracker {
+        StrictTracker {
             state: Vec::new(),
             max_depth: 2048,
         }
     }
 }
 
-impl<S: AsRef<[u8]>, E> StateTracker<S, E>
+impl<S: AsRef<[u8]>, E> StrictTracker<S, E>
 where
     S: AsRef<[u8]>,
     E: From<StructureError> + Clone,

--- a/src/value.rs
+++ b/src/value.rs
@@ -77,7 +77,7 @@ impl<'a> ToBencode for Value<'a> {
 
 impl<'a> FromBencode for Value<'a> {
     const EXPECTED_RECURSION_DEPTH: usize = <Self as ToBencode>::MAX_DEPTH;
-    
+
     fn decode_bencode_object(object: Object) -> Result<Self, crate::decoding::Error> {
         match object {
             Object::Bytes(bytes) => Ok(Value::Bytes(Cow::Owned(bytes.to_owned()))),

--- a/src/value.rs
+++ b/src/value.rs
@@ -27,7 +27,7 @@ use serde::{
 };
 
 use crate::{
-    decoding::{FromBencode, Object},
+    decoding::{FromBencode, Object, StrictObject},
     encoding::{SingleItemEncoder, ToBencode},
 };
 
@@ -78,7 +78,7 @@ impl<'a> ToBencode for Value<'a> {
 impl<'a> FromBencode for Value<'a> {
     const EXPECTED_RECURSION_DEPTH: usize = <Self as ToBencode>::MAX_DEPTH;
 
-    fn decode_bencode_object(object: Object) -> Result<Self, crate::decoding::Error> {
+    fn decode_bencode_object(object: StrictObject) -> Result<Self, crate::decoding::Error> {
         match object {
             Object::Bytes(bytes) => Ok(Value::Bytes(Cow::Owned(bytes.to_owned()))),
             Object::Dict(mut decoder) => {

--- a/tests/core_test.rs
+++ b/tests/core_test.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 
 use bendy::{
-    decoding::{Error as DecodingError, FromBencode, Object},
+    decoding::{Error as DecodingError, FromBencode, Object, StrictObject},
     encoding::{Error as EncodingError, SingleItemEncoder, ToBencode},
 };
 
@@ -371,7 +371,7 @@ where
 }
 
 impl FromBencode for Something {
-    fn decode_bencode_object(object: Object) -> Result<Self, DecodingError>
+    fn decode_bencode_object(object: StrictObject) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -174,7 +174,7 @@ mod decoding_1 {
 }
 
 mod decoding_2 {
-    use bendy::decoding::{Error, FromBencode, Object};
+    use bendy::decoding::{Error, FromBencode, StrictObject};
 
     #[derive(Debug, Eq, PartialEq)]
     struct IntegerWrapper(i64);
@@ -182,7 +182,7 @@ mod decoding_2 {
     impl FromBencode for IntegerWrapper {
         const EXPECTED_RECURSION_DEPTH: usize = 0;
 
-        fn decode_bencode_object(object: Object) -> Result<Self, Error> {
+        fn decode_bencode_object(object: StrictObject) -> Result<Self, Error> {
             // This is an example for content handling. It would also be possible
             // to call  `i64::decode_bencode_object(object)` directly.
             let content = object.try_into_integer()?;
@@ -207,7 +207,7 @@ mod decoding_2 {
 }
 
 mod decoding_3 {
-    use bendy::decoding::{Error, FromBencode, Object};
+    use bendy::decoding::{Error, FromBencode, StrictObject};
 
     #[derive(Debug, Eq, PartialEq)]
     struct StringWrapper(String);
@@ -215,7 +215,7 @@ mod decoding_3 {
     impl FromBencode for StringWrapper {
         const EXPECTED_RECURSION_DEPTH: usize = 0;
 
-        fn decode_bencode_object(object: Object) -> Result<Self, Error> {
+        fn decode_bencode_object(object: StrictObject) -> Result<Self, Error> {
             // This is an example for content handling. It would also be possible
             // to call  `String::decode_bencode_object(object)` directly.
             let content = object.try_into_bytes()?;
@@ -241,7 +241,7 @@ mod decoding_3 {
 
 mod decoding_4 {
     use bendy::{
-        decoding::{Error, FromBencode, Object},
+        decoding::{Error, FromBencode, StrictObject},
         encoding::AsString,
     };
 
@@ -251,7 +251,7 @@ mod decoding_4 {
     impl FromBencode for ByteStringWrapper {
         const EXPECTED_RECURSION_DEPTH: usize = 0;
 
-        fn decode_bencode_object(object: Object) -> Result<Self, Error> {
+        fn decode_bencode_object(object: StrictObject) -> Result<Self, Error> {
             let content = AsString::decode_bencode_object(object)?;
             Ok(ByteStringWrapper(content.0))
         }
@@ -272,7 +272,7 @@ mod decoding_4 {
 }
 
 mod decoding_5 {
-    use bendy::decoding::{Error, FromBencode, Object, ResultExt};
+    use bendy::decoding::{Error, FromBencode, ResultExt, StrictObject};
 
     #[derive(Debug, Eq, PartialEq)]
     struct Example {
@@ -283,7 +283,7 @@ mod decoding_5 {
     impl FromBencode for Example {
         const EXPECTED_RECURSION_DEPTH: usize = 1;
 
-        fn decode_bencode_object(object: Object) -> Result<Self, Error> {
+        fn decode_bencode_object(object: StrictObject) -> Result<Self, Error> {
             let mut counter = None;
             let mut label = None;
 
@@ -331,7 +331,7 @@ mod decoding_5 {
 }
 
 mod decoding_6 {
-    use bendy::decoding::{Error, FromBencode, Object};
+    use bendy::decoding::{Error, FromBencode, StrictObject};
 
     #[derive(Debug, PartialEq, Eq)]
     struct Location(i64, i64);
@@ -339,7 +339,7 @@ mod decoding_6 {
     impl FromBencode for Location {
         const EXPECTED_RECURSION_DEPTH: usize = 1;
 
-        fn decode_bencode_object(object: Object) -> Result<Self, Error> {
+        fn decode_bencode_object(object: StrictObject) -> Result<Self, Error> {
             let mut list = object.try_into_list()?;
 
             let x = list.next_object()?.ok_or(Error::missing_field("x"))?;

--- a/tests/struct_codec.rs
+++ b/tests/struct_codec.rs
@@ -1,5 +1,5 @@
 use bendy::{
-    decoding::{Error as DecodingError, FromBencode, Object},
+    decoding::{Error as DecodingError, FromBencode, StrictObject},
     encoding::{Error as EncodingError, SingleItemEncoder, ToBencode},
 };
 
@@ -23,7 +23,7 @@ impl ToBencode for Example {
 impl FromBencode for Example {
     const EXPECTED_RECURSION_DEPTH: usize = 2;
 
-    fn decode_bencode_object(object: Object) -> Result<Self, DecodingError>
+    fn decode_bencode_object(object: StrictObject) -> Result<Self, DecodingError>
     where
         Self: Sized,
     {


### PR DESCRIPTION
Right now this draft only parameterizes the decoding part to ensure the given structure matches the expectations of @thequux. I am going to implement the encoding part as soon as the decoder got reviewed.

This is the second of three pull requests to introduce relaxed `StateTracker` implementation as @thequux  supposed in https://github.com/P3KI/bendy/issues/44#issuecomment-678833957. (The changeset also still includes more changes as necessary as its based on the not yet merged pull request #46).

Included Changes:

 - Introduce generic parameter for almost any structs in `crate::decoding`.
 - Setup and export type definitions based on the existing `StrictTracker` implementation.

Questions:

 - Should this export both versions (generic and strict) or only the strict version to reduce the amount of breaking changes?
 - What about the definition of `FromBencode`? Right now it is limited to use `StrictByteTracker` to avoid that all of the existing `FromBencode` implementations must be updated. Is this the expected behavior? Should we also introduce a generic version of this trait?

--------

Feel free to nitpick as much as possible :grin: 