### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,68 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  all:
+    name: All
+
+    runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: cargo-registry
+
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: cargo-index
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: cargo-build
+
+    - name: Install Rust Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{matrix.target}}
+        profile: minimal
+        components: clippy
+        override: true
+
+    - name: Info
+      run: |
+        rustup --version
+        cargo --version
+        cargo clippy --version
+
+    - name: Test - Default features
+      run: cargo test --all --verbose
+
+    - name: Test - No default features
+      run: cargo test --all --verbose --no-default-features
+
+    - name: Test - Serde Feature
+      run: cargo test --all --verbose --features serde
+
+    - name: Clippy
+      run: cargo clippy --all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,6 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-        target: ${{matrix.target}}
         profile: minimal
         components: clippy
         override: true
@@ -66,3 +65,13 @@ jobs:
 
     - name: Clippy
       run: cargo clippy --all
+
+    - name: Install Nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        components: rustfmt
+
+    - name: Check Formatting
+      run: cargo +nightly fmt --all -- --check

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -284,7 +284,7 @@ impl<'obj, 'ser: 'obj> DictDecoder<'obj, 'ser> {
     /// dictionary. This method should be used to check for encoding errors if
     /// [`DictDecoder::next_pair`] is not called until it returns `Ok(None)`.
     pub fn consume_all(&mut self) -> Result<(), Error> {
-        while let Some(_) = self.next_pair()? {
+        while self.next_pair()?.is_some() {
             // just drop the items
         }
         Ok(())
@@ -334,7 +334,7 @@ impl<'obj, 'ser: 'obj> ListDecoder<'obj, 'ser> {
     ///
     /// [`Ok(())`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
     pub fn consume_all(&mut self) -> Result<(), Error> {
-        while let Some(_) = self.next_object()? {
+        while self.next_object()?.is_some() {
             // just drop the items
         }
         Ok(())


### PR DESCRIPTION
I'm not sure if you've considered using GitHub Actions to do CI, but it's easy enough, so I thought I'd write a PR that adds it.

I mostly copy-pastaed this from another project, so don't feel bad if you'd prefer not to merge it for whatever reason.

Adds a github actions workflow that:

- Runs on ubuntu. Since this crate doesn't include any platform-specific
  code, it seems unnecessary to run on macOS and Windows, although that
  could easily be added.

- Fails if rust produces any warnings.

- Caches the cargo registry, cargo index, and build folder.

- Runs tests with default features, no default features, and with the
  serde feature.

- Runs clippy.

Clippy had some minor complaints, so I also fixed those.