### PR TITLE
Switch to `snafu` as error handling library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ codegen-units = 1
 ### DEPENDENCIES ###############################################################
 
 [dependencies]
-failure = { version = "^0.1.3", default_features = false, features = ["derive"] }
 serde_ = { version = "^1.0" ,  optional = true, package = "serde" }
 serde_bytes = { version = "^0.11.3", optional = true }
+snafu = { version = "^0.6.9", default_features = false }
 
 [dev-dependencies]
 regex = "^1.0"
@@ -47,7 +47,7 @@ default = ["std"]
 
 # Provide implementations for common standard library types like `Vec<T>` and
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
-std = ["failure/std"]
+std = ["failure/std", "snafu/std"]
 
 # Support serde serialization to and deserialization from bencode
 serde = ["serde_", "serde_bytes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_bytes = { version = "^0.11.3", optional = true }
 snafu = { version = "^0.6.9", default_features = false }
 
 [dev-dependencies]
+anyhow = "^1.0"
 regex = "^1.0"
 serde_derive = "^1.0"
 
@@ -47,7 +48,7 @@ default = ["std"]
 
 # Provide implementations for common standard library types like `Vec<T>` and
 # `HashMap<K, V>`. Requires a dependency on the Rust standard library.
-std = ["failure/std", "snafu/std"]
+std = ["snafu/std"]
 
 # Support serde serialization to and deserialization from bencode
 serde = ["serde_", "serde_bytes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ serde_bytes = { version = "^0.11.3", optional = true }
 snafu = { version = "^0.6.9", default_features = false }
 
 [dev-dependencies]
-anyhow = "^1.0"
 regex = "^1.0"
 serde_derive = "^1.0"
 

--- a/examples/encode_torrent.rs
+++ b/examples/encode_torrent.rs
@@ -15,8 +15,7 @@
 
 use std::io::Write;
 
-use anyhow::Result;
-use bendy::encoding::{AsString, Error as EncodingError, SingleItemEncoder, ToBencode};
+use bendy::encoding::{AsString, Error, SingleItemEncoder, ToBencode};
 
 /// Main struct containing all required information.
 ///
@@ -50,7 +49,7 @@ impl ToBencode for MetaInfo {
     // around the info struct.
     const MAX_DEPTH: usize = Info::MAX_DEPTH + 1;
 
-    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), EncodingError> {
+    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), Error> {
         encoder.emit_dict(|mut e| {
             e.emit_pair(b"announce", &self.announce)?;
 
@@ -80,7 +79,7 @@ impl ToBencode for Info {
     // as flat values, i.e. strings or integers.
     const MAX_DEPTH: usize = 1;
 
-    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), EncodingError> {
+    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), Error> {
         encoder.emit_dict(|mut e| {
             e.emit_pair(b"length", &self.file_length)?;
             e.emit_pair(b"name", &self.name)?;
@@ -91,7 +90,7 @@ impl ToBencode for Info {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let torrent = MetaInfo {
         announce: "http://bttracker.debian.org:6969/announce".to_owned(),
         comment: Some("\"Debian CD from cdimage.debian.org\"".to_owned()),

--- a/examples/encode_torrent.rs
+++ b/examples/encode_torrent.rs
@@ -15,8 +15,8 @@
 
 use std::io::Write;
 
+use anyhow::Result;
 use bendy::encoding::{AsString, Error as EncodingError, SingleItemEncoder, ToBencode};
-use failure::Error;
 
 /// Main struct containing all required information.
 ///
@@ -91,7 +91,7 @@ impl ToBencode for Info {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<()> {
     let torrent = MetaInfo {
         announce: "http://bttracker.debian.org:6969/announce".to_owned(),
         comment: Some("\"Debian CD from cdimage.debian.org\"".to_owned()),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-required_version = "1.4.22"
+required_version = "1.4.24"
 edition = "2018"
 
 format_code_in_doc_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-required_version = "1.4.24"
+required_version = "1.4.26"
 edition = "2018"
 
 format_code_in_doc_comments = true

--- a/src/decoding/decoder.rs
+++ b/src/decoding/decoder.rs
@@ -146,17 +146,20 @@ impl<'ser> Decoder<'ser> {
 
                 let curpos = self.offset;
                 let ival = self.take_int(':')?;
-                let len = usize::from_str_radix(ival, 10).map_err(|_| {
-                    StructureError::SyntaxError(format!("Invalid integer at offset {}", curpos))
-                })?;
+                let len =
+                    usize::from_str_radix(ival, 10).map_err(|_| StructureError::SyntaxError {
+                        unexpected: format!("Invalid integer at offset {}", curpos),
+                    })?;
                 Token::String(self.take_chunk(len).ok_or(StructureError::UnexpectedEof)?)
             },
             tok => {
-                return Err(Error::from(StructureError::SyntaxError(format!(
-                    "Invalid token starting with {:?} at offset {}",
-                    tok,
-                    self.offset - 1
-                ))));
+                return Err(Error::from(StructureError::SyntaxError {
+                    unexpected: format!(
+                        "Invalid token starting with {:?} at offset {}",
+                        tok,
+                        self.offset - 1
+                    ),
+                }));
             },
         };
 

--- a/src/decoding/error.rs
+++ b/src/decoding/error.rs
@@ -1,52 +1,54 @@
-#[cfg(not(feature = "std"))]
-use alloc::{str::Utf8Error, string::FromUtf8Error};
-#[cfg(not(feature = "std"))]
-use core::num::ParseIntError;
-
 use alloc::{
     format,
-    string::{String, ToString},
+    str::Utf8Error,
+    string::{FromUtf8Error, String, ToString},
 };
-use core::fmt::{self, Display, Formatter};
+use core::{fmt::Display, num::ParseIntError};
 
 #[cfg(feature = "std")]
-use std::{error::Error as StdError, sync::Arc};
+use std::sync::Arc;
 
-use failure::Fail;
+use snafu::Snafu;
 
-use crate::state_tracker::StructureError;
+use crate::state_tracker;
 
-#[derive(Debug, Clone, Fail)]
+#[derive(Debug, Clone, Snafu)]
 pub struct Error {
-    #[fail(context)]
     context: Option<String>,
-    #[fail(cause)]
-    error: ErrorKind,
+    source: ErrorKind,
 }
 
-/// An enumeration of potential errors that appear during bencode deserialization.
-#[derive(Debug, Clone, Fail)]
+// An enumeration of potential errors that apepar during bencode deserialization.
+#[derive(Debug, Clone, Snafu)]
 pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(feature = "std")]
-    #[fail(display = "malformed content discovered: {}", _0)]
-    MalformedContent(Arc<failure::Error>),
+    #[snafu(display("malformed content discovered: {}", source))]
+    MalformedContent { source: Arc<dyn std::error::Error> },
+
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(not(feature = "std"))]
-    #[fail(display = "malformed content discovered")]
+    #[snafu(display("malformed content discovered"))]
     MalformedContent,
+
     /// Error that occurs if the serialized structure is incomplete.
-    #[fail(display = "missing field: {}", _0)]
-    MissingField(String),
-    /// Error in the bencode structure (e.g. a missing field end separator).
-    #[fail(display = "bencode encoding corrupted ({})", _0)]
-    StructureError(#[fail(cause)] StructureError),
+    #[snafu(display("missing field: {}", field))]
+    MissingField { field: String },
+
+    /// Error in the bencode structure (e.g. a missing field and seperator).
+    #[snafu(display("bencode encoding corrupted ({})", source))]
+    StructureError { source: state_tracker::StructureError },
+
     /// Error that occurs if the serialized structure contains an unexpected field.
-    #[fail(display = "unexpected field: {}", _0)]
-    UnexpectedField(String),
+    #[snafu(display("unexpected field: {}", field))]
+    UnexpectedField { field: String },
+
     /// Error through an unexpected bencode token during deserialization.
-    #[fail(display = "discovered {} but expected {}", _0, _1)]
-    UnexpectedToken(String, String),
+    #[snafu(display("discovered {} but expected {}", expected, discovered))]
+    UnexpectedToken {
+        expected: String,
+        discovered: String,
+    },
 }
 
 pub trait ResultExt {
@@ -67,47 +69,39 @@ impl Error {
     /// Raised when there is a general error while deserializing a type.
     /// The message should not be capitalized and should not end with a period.
     #[cfg(feature = "std")]
-    pub fn malformed_content(cause: impl Into<failure::Error>) -> Error {
-        let error = Arc::new(cause.into());
-        Self::from(ErrorKind::MalformedContent(error))
+    pub fn malformed_content<SourceT>(source: SourceT) -> Self
+    where
+        SourceT: std::error::Error + Send + Sync + 'static
+    {
+        let error = Arc::new(source);
+        ErrorKind::MalformedContent { source: error }.into()
     }
 
     #[cfg(not(feature = "std"))]
-    pub fn malformed_content<T>(_cause: T) -> Error {
+    pub fn malformed_content<T>(_cause: T) -> Self {
         Self::from(ErrorKind::MalformedContent)
     }
 
-    /// Returns a `Error::MissingField` which contains the name of the field.
-    pub fn missing_field(field_name: impl Display) -> Error {
-        Self::from(ErrorKind::MissingField(field_name.to_string()))
+    // Returns a `Error::MissingField` which contains the name of the field.
+    pub fn missing_field(field_name: impl Display) -> Self {
+        Error::from(ErrorKind::MissingField {
+            field: field_name.to_string(),
+        })
     }
 
     /// Returns a `Error::UnexpectedField` which contains the name of the field.
-    pub fn unexpected_field(field_name: impl Display) -> Error {
-        Self::from(ErrorKind::UnexpectedField(field_name.to_string()))
+    pub fn unexpected_field(field_name: impl Display) -> Self {
+        Error::from(ErrorKind::UnexpectedField {
+            field: field_name.to_string(),
+        })
     }
 
     /// Returns a `Error::UnexpectedElement` which contains a custom error message.
-    pub fn unexpected_token(expected: impl Display, discovered: impl Display) -> Error {
-        Self::from(ErrorKind::UnexpectedToken(
-            expected.to_string(),
-            discovered.to_string(),
-        ))
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match &self.context {
-            Some(context) => write!(f, "Error: {} in {}", self.error, context),
-            None => write!(f, "Error: {}", self.error),
-        }
-    }
-}
-
-impl From<StructureError> for Error {
-    fn from(error: StructureError) -> Self {
-        Self::from(ErrorKind::StructureError(error))
+    pub fn unexpected_token(expected: impl Display, discovered: impl Display) -> Self {
+        Error::from(ErrorKind::UnexpectedToken {
+            expected: expected.to_string(),
+            discovered: discovered.to_string(),
+        })
     }
 }
 
@@ -115,41 +109,37 @@ impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
         Self {
             context: None,
-            error: kind,
+            source: kind,
         }
     }
 }
 
-#[cfg(not(feature = "std"))]
+impl From<state_tracker::StructureError> for Error {
+    fn from(error: state_tracker::StructureError) -> Self {
+        Self::from(ErrorKind::StructureError { source: error })
+    }
+}
+
 impl From<FromUtf8Error> for Error {
     fn from(err: FromUtf8Error) -> Self {
         Self::malformed_content(err)
     }
 }
 
-#[cfg(not(feature = "std"))]
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Self {
         Self::malformed_content(err)
     }
 }
 
-#[cfg(not(feature = "std"))]
 impl From<ParseIntError> for Error {
     fn from(err: ParseIntError) -> Self {
         Self::malformed_content(err)
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: StdError + Send + Sync + 'static> From<T> for Error {
-    fn from(error: T) -> Self {
-        Self::malformed_content(error)
-    }
-}
-
 impl<T> ResultExt for Result<T, Error> {
-    fn context(self, context: impl Display) -> Result<T, Error> {
+    fn context(self, context: impl Display) -> Self {
         self.map_err(|err| err.context(context))
     }
 }

--- a/src/decoding/error.rs
+++ b/src/decoding/error.rs
@@ -18,7 +18,7 @@ pub struct Error {
     source: ErrorKind,
 }
 
-// An enumeration of potential errors that apepar during bencode deserialization.
+// An enumeration of potential errors that appear during bencode deserialization.
 #[derive(Debug, Clone, Snafu)]
 pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid semantics.

--- a/src/decoding/error.rs
+++ b/src/decoding/error.rs
@@ -37,7 +37,9 @@ pub enum ErrorKind {
 
     /// Error in the bencode structure (e.g. a missing field and seperator).
     #[snafu(display("bencode encoding corrupted ({})", source))]
-    StructureError { source: state_tracker::StructureError },
+    StructureError {
+        source: state_tracker::StructureError,
+    },
 
     /// Error that occurs if the serialized structure contains an unexpected field.
     #[snafu(display("unexpected field: {}", field))]
@@ -71,7 +73,7 @@ impl Error {
     #[cfg(feature = "std")]
     pub fn malformed_content<SourceT>(source: SourceT) -> Self
     where
-        SourceT: std::error::Error + Send + Sync + 'static
+        SourceT: std::error::Error + Send + Sync + 'static,
     {
         let error = Arc::new(source);
         ErrorKind::MalformedContent { source: error }.into()

--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -389,9 +389,9 @@ impl UnsortedDictEncoder {
         }
 
         if !value_written {
-            self.error = Err(Error::from(StructureError::InvalidState(
-                "No value was emitted".to_owned(),
-            )));
+            self.error = Err(Error::from(StructureError::InvalidState {
+                state: "No value was emitted".to_owned(),
+            }));
         } else {
             self.error = encoder.state.observe_eof().map_err(Error::from);
         }
@@ -429,10 +429,12 @@ impl UnsortedDictEncoder {
         let vacancy = match self.content.entry(unencoded_key.to_owned()) {
             Entry::Vacant(vacancy) => vacancy,
             Entry::Occupied(occupation) => {
-                self.error = Err(Error::from(StructureError::InvalidState(format!(
-                    "Duplicate key {}",
-                    String::from_utf8_lossy(occupation.key())
-                ))));
+                self.error = Err(Error::from(StructureError::InvalidState {
+                    state: format!(
+                        "Duplicate key {}",
+                        String::from_utf8_lossy(occupation.key())
+                    ),
+                }));
                 return self.error.clone();
             },
         };

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -1,28 +1,32 @@
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
-use failure::Fail;
+use snafu::Snafu;
 
-use crate::state_tracker::StructureError;
+use crate::state_tracker;
 
-#[derive(Debug, Clone, Fail)]
-#[fail(display = "encoding failed: {}", _0)]
-pub struct Error(#[fail(cause)] pub ErrorKind);
+#[derive(Debug, Clone, Snafu)]
+#[snafu(display("encoding failed: {}", source))]
+pub struct Error {
+    pub source: ErrorKind
+}
 
 /// An enumeration of potential errors that appear during bencode encoding.
-#[derive(Debug, Clone, Fail)]
+#[derive(Debug, Clone, Snafu)]
 pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(feature = "std")]
-    #[fail(display = "malformed content discovered: {}", _0)]
-    MalformedContent(Arc<failure::Error>),
+    #[snafu(display("malformed content discovered: {}", source))]
+    MalformedContent { source: Arc<dyn std::error::Error + Send + Sync>},
+
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(not(feature = "std"))]
-    #[fail(display = "malformed content discovered")]
+    #[snafu(display("malformed content discovered"))]
     MalformedContent,
+
     /// Error in the bencode structure (e.g. a missing field end separator).
-    #[fail(display = "bencode encoding corrupted")]
-    StructureError(#[fail(cause)] StructureError),
+    #[snafu(display("bencode encoding corrupted"))]
+    StructureError { source: state_tracker::StructureError } ,
 }
 
 impl Error {
@@ -32,25 +36,30 @@ impl Error {
     /// Note that, when building with no_std, this method accepts any type as
     /// its argument.
     #[cfg(feature = "std")]
-    pub fn malformed_content(cause: impl Into<failure::Error>) -> Error {
-        let error = Arc::new(cause.into());
-        Self(ErrorKind::MalformedContent(error))
+    pub fn malformed_content<SourceT>(source: SourceT) -> Self
+    where
+        SourceT: std::error::Error + Send + Sync + 'static
+    {
+        let error = Arc::new(source);
+        ErrorKind::MalformedContent { source: error }.into()
     }
 
     #[cfg(not(feature = "std"))]
-    pub fn malformed_content<T>(_cause: T) -> Error {
-        Self(ErrorKind::MalformedContent)
+    pub fn malformed_content<T>(_cause: T) -> Self {
+        Self::from(ErrorKind::MalformedContent)
     }
 }
 
-impl From<StructureError> for Error {
-    fn from(error: StructureError) -> Self {
-        Self(ErrorKind::StructureError(error))
+impl From<state_tracker::StructureError> for Error {
+    fn from(error: state_tracker::StructureError) -> Self {
+        Self::from(ErrorKind::StructureError { source: error })
     }
 }
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
-        Self(kind)
+        Self {
+            source: kind
+        }
     }
 }

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -8,7 +8,7 @@ use crate::state_tracker;
 #[derive(Debug, Clone, Snafu)]
 #[snafu(display("encoding failed: {}", source))]
 pub struct Error {
-    pub source: ErrorKind
+    pub source: ErrorKind,
 }
 
 /// An enumeration of potential errors that appear during bencode encoding.
@@ -17,7 +17,9 @@ pub enum ErrorKind {
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(feature = "std")]
     #[snafu(display("malformed content discovered: {}", source))]
-    MalformedContent { source: Arc<dyn std::error::Error + Send + Sync>},
+    MalformedContent {
+        source: Arc<dyn std::error::Error + Send + Sync>,
+    },
 
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(not(feature = "std"))]
@@ -26,7 +28,9 @@ pub enum ErrorKind {
 
     /// Error in the bencode structure (e.g. a missing field end separator).
     #[snafu(display("bencode encoding corrupted"))]
-    StructureError { source: state_tracker::StructureError } ,
+    StructureError {
+        source: state_tracker::StructureError,
+    },
 }
 
 impl Error {
@@ -38,7 +42,7 @@ impl Error {
     #[cfg(feature = "std")]
     pub fn malformed_content<SourceT>(source: SourceT) -> Self
     where
-        SourceT: std::error::Error + Send + Sync + 'static
+        SourceT: std::error::Error + Send + Sync + 'static,
     {
         let error = Arc::new(source);
         ErrorKind::MalformedContent { source: error }.into()
@@ -58,8 +62,6 @@ impl From<state_tracker::StructureError> for Error {
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
-        Self {
-            source: kind
-        }
+        Self { source: kind }
     }
 }

--- a/src/state_tracker/structure_error.rs
+++ b/src/state_tracker/structure_error.rs
@@ -8,37 +8,42 @@ use core::fmt::Display;
 #[cfg(feature = "std")]
 use std::fmt::Display;
 
-use failure::Fail;
+use snafu::Snafu;
 
 /// An encoding or decoding error
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Fail)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Snafu)]
 pub enum StructureError {
-    #[fail(display = "Saw the wrong type of token: {}", _0)]
     /// Wrong type of token detected.
-    InvalidState(String),
-    #[fail(display = "Keys were not sorted")]
+    #[snafu(display("Saw the wrong type of token: {}", state))]
+    InvalidState { state: String },
+
     /// Keys were not sorted.
+    #[snafu(display("Keys were not sorted"))]
     UnsortedKeys,
-    #[fail(display = "Reached EOF in the middle of a message")]
+
     /// EOF reached to early.
+    #[snafu(display("Reached EOF in the middle of a message"))]
     UnexpectedEof,
-    #[fail(display = "Malformed number of unexpected character: {}", _0)]
+
     /// Unexpected characters detected.
-    SyntaxError(String),
-    #[fail(display = "Maximum nesting depth exceeded")]
+    #[snafu(display("Malformed number of unexpected character: {}", unexpected))]
+    SyntaxError { unexpected: String },
+
     /// Exceeded the recursion limit.
+    #[snafu(display("Maximum nesting depth exceeded"))]
     NestingTooDeep,
 }
 
 impl StructureError {
     pub fn unexpected(expected: impl Display, got: char, offset: usize) -> Self {
-        StructureError::SyntaxError(format!(
-            "Expected {}, got {:?} at offset {}",
-            expected, got, offset
-        ))
+        StructureError::SyntaxError {
+            unexpected: format!("Expected {}, got {:?} at offset {}", expected, got, offset),
+        }
     }
 
     pub fn invalid_state(expected: impl Display) -> Self {
-        StructureError::InvalidState(expected.to_string())
+        StructureError::InvalidState {
+            state: expected.to_string(),
+        }
     }
 }


### PR DESCRIPTION
This is my first attempt to replace `failure` with `snafu` as `failure` got officially deprcated. It should finally fix #40. Even if it seems like the CI doesn't like this changeset... Travis CI just stucks and on GHA the macos-latest builder are not able to download `snafu_derive`...

 - https://travis-ci.org/github/0ndorio/bendy/builds/743496259
 - https://github.com/0ndorio/bendy/actions/runs/362313469


@casey could you review this? I hadn't much chance to program rust during this year and I assume @thequux is still quite busy. Feel free to nitpick as much as you like. 
