### PR TITLE
Fix bad CI cache on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install gnu-tar
-          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+          echo /usr/local/opt/gnu-tar/libexec/gnubin > $GITHUB_PATH
 
       - name: Cache Cargo
         uses: actions/cache@v2
@@ -85,7 +85,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install gnu-tar
-          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+          echo /usr/local/opt/gnu-tar/libexec/gnubin > $GITHUB_PATH
 
       - name: Cache Cargo
         uses: actions/cache@v2
@@ -143,7 +143,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install gnu-tar
-          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+          echo /usr/local/opt/gnu-tar/libexec/gnubin > $GITHUB_PATH
 
       - name: Cache Cargo
         uses: actions/cache@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
-  formating:
+  formatting:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
@@ -36,13 +36,21 @@ jobs:
           components: clippy
           override: true
 
+      # An issue with BSD Tar causes sporadic failures on macOS.
+      # c.f https://github.com/actions/cache/issues/403
+      - name: Install GNU Tar
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
+          key: 0-${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo clippy --all
 
@@ -71,19 +79,27 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
+      # An issue with BSD Tar causes sporadic failures on macOS.
+      # c.f https://github.com/actions/cache/issues/403
+      - name: Install GNU Tar
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
+          key: 0-${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Target Directory
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ matrix.os }}-bendy-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: 0-${{ matrix.os }}-bendy-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -121,14 +137,21 @@ jobs:
           override: true
           target: thumbv7m-none-eabi
 
+      # An issue with BSD Tar causes sporadic failures on macOS.
+      # c.f https://github.com/actions/cache/issues/403
+      - name: Install GNU Tar
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
+          key: 0-${{ matrix.os }}-bendy-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build with Rust 1.36.0 for an embedded target
         run: cargo build --all --no-default-features --target=thumbv7m-none-eabi
-


### PR DESCRIPTION
The BSD Tar that ships with macOS has a bug that can cause it to create
empty tar files, which can cause bad caches to be created on GitHub
Actions.

An example of this error is here:

    https://github.com/P3KI/bendy/pull/48/checks?check_run_id=1421741031#step:9:39

And here are a couple discussions:

    https://github.com/actions/cache/issues/403
    https://github.com/actions/toolkit/pull/553

As a workaround, this patch installs GNU Tar on macos in all jobs that
use the cache. It also adds `0-` to all cache keys to make sure that
future CI builds don't hit the old, corrupted cache. This can be removed
once `Cargo.lock` changes.