### PR TITLE
Remove rustfmt required version

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 unstable_features = true
 
-required_version = "1.4.22"
 edition = "2018"
 
 format_code_in_doc_comments = true


### PR DESCRIPTION
Unless CI is pinned to a specific version of rust, or specific nightly,
`required_version` in `rustfmt.toml` will periodically cause CI to start
failing, when a new version of rustfmt is included in rust.

I ran into this in one of my own project, and decided that removing
`required_version` was probably preferable to pinning, so that's what
this patch does.

If there's a hard requirement to stay on a particular version of
rustfmt, then pinning is probably better.