### PR TITLE
Got rid of the encoding::ErrorKind struct. Its functionality has been…

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -123,7 +123,7 @@ mod to_bencode;
 
 pub use self::{
     encoder::{Encoder, SingleItemEncoder, SortedDictEncoder, UnsortedDictEncoder},
-    error::{Error, ErrorKind},
+    error::Error,
     printable_integer::PrintableInteger,
     to_bencode::{AsString, ToBencode},
 };

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -45,7 +45,7 @@ impl Error {
 
     #[cfg(not(feature = "std"))]
     pub fn malformed_content<T>(_cause: T) -> Self {
-        Self::from(ErrorKind::MalformedContent)
+        Error::MalformedContent
     }
 }
 

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -5,15 +5,10 @@ use snafu::Snafu;
 
 use crate::state_tracker;
 
-#[derive(Debug, Clone, Snafu)]
-#[snafu(display("encoding failed: {}", source))]
-pub struct Error {
-    pub source: ErrorKind,
-}
-
 /// An enumeration of potential errors that appear during bencode encoding.
 #[derive(Debug, Clone, Snafu)]
-pub enum ErrorKind {
+#[non_exhaustive]
+pub enum Error {
     /// Error that occurs if the serialized structure contains invalid semantics.
     #[cfg(feature = "std")]
     #[snafu(display("malformed content discovered: {}", source))]
@@ -45,7 +40,7 @@ impl Error {
         SourceT: std::error::Error + Send + Sync + 'static,
     {
         let error = Arc::new(source);
-        ErrorKind::MalformedContent { source: error }.into()
+        Error::MalformedContent { source: error }
     }
 
     #[cfg(not(feature = "std"))]
@@ -56,12 +51,6 @@ impl Error {
 
 impl From<state_tracker::StructureError> for Error {
     fn from(error: state_tracker::StructureError) -> Self {
-        Self::from(ErrorKind::StructureError { source: error })
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Self {
-        Self { source: kind }
+        Error::StructureError { source: error }
     }
 }


### PR DESCRIPTION
… folded into encoding::Error